### PR TITLE
Add Capistrano dependencies for deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,6 +134,8 @@ group :development do
   gem 'capistrano-passenger', '>= 0.1.1'
   gem 'capistrano-rbenv'
   gem 'capistrano-rails'
+  gem 'ed25519'
+  gem 'bcrypt_pbkdf'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     ast (2.4.1)
     awesome_print (1.8.0)
     barby (0.6.8)
+    bcrypt_pbkdf (1.1.0)
     better_errors (2.7.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -134,6 +135,7 @@ GEM
     database_cleaner (1.8.5)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
+    ed25519 (1.2.4)
     erubi (1.10.0)
     etc (1.1.0)
     exception_notification (4.4.0)
@@ -377,6 +379,7 @@ DEPENDENCIES
   apparition
   awesome_print
   barby
+  bcrypt_pbkdf
   better_errors
   binding_of_caller
   bootstrap-select-rails
@@ -393,6 +396,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2.0)
   data-confirm-modal
   database_cleaner
+  ed25519
   exception_notification
   factory_bot_rails
   font-awesome-rails


### PR DESCRIPTION
After updating to Ruby 2.7.3, when deploying to dev, capistrano required
two additional dependencies. `ed25519` and `bcrypt_pbkdf`.