### PR TITLE
Add guard package to rerun related tests on file changes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,9 +103,12 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'fuubar'
 
+  # Watch files for changes and re-run tests
+  gem 'guard'
+  gem 'guard-rspec', require: false
+
   # Add some pry/rails console helpers for development
-  gem 'pry', '0.12.2'
-  gem 'pry-coolline'
+  gem 'pry', '~> 0.13.1'
   gem 'pry-byebug'
   gem 'awesome_print'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     bootstrap-select-rails (1.13.8)
     browser (4.2.0)
     builder (3.2.4)
-    byebug (11.0.1)
+    byebug (11.1.3)
     capistrano (3.14.1)
       airbrussh (>= 1.0.0)
       i18n
@@ -126,8 +126,6 @@ GEM
     coffee-script-source (1.12.2)
     commonjs (0.2.7)
     concurrent-ruby (1.1.8)
-    coolline (0.5.0)
-      unicode_utils (~> 1.4)
     crass (1.0.6)
     data-confirm-modal (1.6.3)
       railties (>= 3.0)
@@ -157,11 +155,26 @@ GEM
     ffi (1.13.1)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
+    formatador (0.3.0)
     fuubar (2.5.0)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    guard (2.17.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
     hashie (4.1.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -194,15 +207,17 @@ GEM
     loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lumberjack (1.2.8)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mini_mime (1.1.0)
     mini_portile2 (2.4.0)
     minitest (5.14.4)
     multipart-post (2.1.1)
     mysql2 (0.5.3)
+    nenv (0.3.0)
     net-ldap (0.16.2)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
@@ -210,6 +225,9 @@ GEM
     nio4r (2.5.7)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
@@ -227,14 +245,12 @@ GEM
       rack
       rake (>= 0.8.1)
     powerpack (0.1.2)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-byebug (3.7.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (~> 0.10)
-    pry-coolline (0.2.5)
-      coolline (~> 0.5)
+      pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.5)
@@ -281,6 +297,10 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 0.1)
     rqrcode_core (0.1.2)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -327,6 +347,7 @@ GEM
     sentry-ruby-core (4.4.2)
       concurrent-ruby
       faraday
+    shellany (0.0.1)
     slack-notifier (2.3.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -355,7 +376,6 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
-    unicode_utils (1.4.0)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -397,6 +417,8 @@ DEPENDENCIES
   factory_bot_rails
   font-awesome-rails
   fuubar
+  guard
+  guard-rspec
   i18n-js
   jbuilder (~> 2.0)
   jquery-rails
@@ -411,9 +433,8 @@ DEPENDENCIES
   omniauth-shibboleth-passive
   paper_trail
   passenger
-  pry (= 0.12.2)
+  pry (~> 0.13.1)
   pry-byebug
-  pry-coolline
   pry-rails
   puma (~> 3.0)
   pundit

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,70 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: "RAILS_ENV=development bundle exec rspec" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+
+  # Rails files
+  rails = dsl.rails(view_extensions: %w(erb haml slim))
+  dsl.watch_spec_files_for(rails.app_files)
+  dsl.watch_spec_files_for(rails.views)
+
+  watch(rails.controllers) do |m|
+    [
+      rspec.spec.call("routing/#{m[1]}_routing"),
+      rspec.spec.call("controllers/#{m[1]}_controller"),
+      rspec.spec.call("acceptance/#{m[1]}")
+    ]
+  end
+
+  # Rails config changes
+  watch(rails.spec_helper)     { rspec.spec_dir }
+  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+  # Capybara features specs
+  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+
+  # Turnip features and steps
+  watch(%r{^spec/acceptance/(.+)\.feature$})
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+  end
+end


### PR DESCRIPTION
Added [guard](https://github.com/guard/guard) and [guard-rspec](https://github.com/guard/guard-rspec) to support test driven development.  Using the standard guardfile with minor addition of adding `RAILS_ENV=development` before the `bundle exec rspec` command.

Guard complained about an outdated version of pry and related plugins, so updated those too.
