### PR TITLE
Fix page not found issue where an unknown URL with format extension raised unhandled exception

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   include SessionsHelper
   include Pundit
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   helper Starburst::AnnouncementsHelper
 
@@ -39,11 +39,8 @@ class ApplicationController < ActionController::Base
     @admin_view = true
   end
 
-  def render_404
-    respond_to do |format|
-      format.html { render template: 'errors/not_found', layout: 'layouts/application', status: 404 }
-      format.all { render nothing: true, status: 404 }
-    end
+  def render_not_found
+    render template: 'errors/not_found', layout: 'layouts/application', status: 404 
   end
 
   private

--- a/spec/controllers/redirect_spec.rb
+++ b/spec/controllers/redirect_spec.rb
@@ -15,6 +15,14 @@ describe RedirectController do
         get :index, params: {keyword: "test404#{url.keyword}" } 
         expect(response.status).to eq(404)
       end
+
+      it 'renders 404 page regardless of format param' do
+        get :index, params: {keyword: "test404#{url.keyword}", format: nil }
+        expect(response.status).to eq(404)
+
+        get :index, params: {keyword: "test404#{url.keyword}", format: "php" }
+        expect(response.status).to eq(404)
+      end
     end
   end
 


### PR DESCRIPTION
**Problem**
After the latest update to ruby-2.7 an new issue emerged in the testing environment. Occasionally, we would receive notifications for unhandled exceptions for `ActionView::MissingTemplate`. For example, getting `/html/public/index.php` would give:
```
An ActionView::MissingTemplate occurred while GET </html/public/index.php> was processed by redirect#index
Exception
Missing template redirect/index, application/index with {:locale=>[:en], :formats=>[nil], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :coffee, :jbuilder]}. Searched in:
 * "/swadm/web/z/releases/20210706184342/app/views"
 * "/swadm/web/z/shared/bundle/ruby/2.7.0/bundler/gems/starburst-ff8fd1f8fbb7/app/views"
 * "/swadm/web/z/shared/bundle/ruby/2.7.0/gems/twitter-bootstrap-rails-4.0.0/app/views"
Hostname
cla-z-dev.oit.umn.edu
Backtrace
app/controllers/application_controller.rb:45:in `block (2 levels) in render_404'
app/controllers/application_controller.rb:43:in `render_404'
Data
server: z-dev.cla.umn.edu
```

**Fix**
Removed different renderings based on `:format` parameter. Tests included.

Closes #29.