### PR TITLE
Change Apparition gem source to github.com

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ group :development, :test do
   gem 'rspec-rails', "~> 4.0"
   gem 'capybara', "~> 3.15"
   gem 'capybara-screenshot', "~> 1.0"
-  gem 'apparition', "~> 0.6"
+  gem 'apparition', github: 'twalpole/apparition'
   gem 'launchy', "~> 2.4"
   gem 'factory_bot_rails', "~> 6.2"
   gem 'database_cleaner', "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,14 @@ GIT
       less-rails (>= 3.0, < 5.0)
       railties (>= 5.0, < 7.0)
 
+GIT
+  remote: https://github.com/twalpole/apparition.git
+  revision: ca86be4d54af835d531dbcd2b86e7b2c77f85f34
+  specs:
+    apparition (0.6.0)
+      capybara (~> 3.13, < 4)
+      websocket-driver (>= 0.6.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -97,9 +105,6 @@ GEM
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     ast (2.4.2)
     awesome_print (1.9.2)
     barby (0.6.8)
@@ -251,7 +256,7 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.3)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     multipart-post (2.1.1)
     mysql2 (0.5.3)
@@ -261,8 +266,8 @@ GEM
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
     nio4r (2.5.7)
-    nokogiri (1.11.7)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.12.2)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -447,7 +452,7 @@ DEPENDENCIES
   addressable (~> 2.8)
   ajax-datatables-rails!
   annotate (~> 3.1)
-  apparition (~> 0.6)
+  apparition!
   awesome_print (~> 1.8)
   barby (~> 0.6)
   bcrypt_pbkdf (~> 1.1)


### PR DESCRIPTION
The latest version of apparition can create a lot of noise with "unknown keyword: :type: " warnings when running rspec, like:

```console
...
Unexpected inner loop exception: unknown keyword: :type: unknown keyword: :type: ["/Users/james/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/apparition-0.6.0/lib/capybara/apparition/page.rb:466:in `block in register_event_handlers'", "/Users/james/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/apparition-0.6.0/lib/capybara/apparition/driver/chrome_client.rb:209:in `block in process_handlers'", "/Users/james/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/apparition-0.6.0/lib/capybara/apparition/driver/chrome_client.rb:207:in `each'", "/Users/james/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/apparition-0.6.0/lib/capybara/apparition/driver/chrome_client.rb:207:in `process_handlers'", "/Users/james/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/apparition-0.6.0/lib/capybara/apparition/driver/chrome_client.rb:185:in `block in process_messages'", "/Users/james/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/apparition-0.6.0/lib/capybara/apparition/driver/chrome_client.rb:175:in `loop'", "/Users/james/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/apparition-0.6.0/lib/capybara/apparition/driver/chrome_client.rb:175:in `process_messages'", "/Users/james/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/apparition-0.6.0/lib/capybara/apparition/driver/chrome_client.rb:215:in `block in start_threads'"]
...
```

This is fixed in https://github.com/twalpole/apparition/pull/79, but not yet deployed to rubygems.
