### PR TITLE
Disable submit button if add new member form is blank

### DIFF
--- a/app/assets/javascripts/group_members.js
+++ b/app/assets/javascripts/group_members.js
@@ -10,3 +10,29 @@ $(document).bind('turbolinks:load', function () {
       } ]
    });
 });
+
+// new member form submit button disabled unless
+// all required fields have some value
+$(() => {
+  const newMemberForm = document.querySelector("form.new_member");
+  if (!newMemberForm) return;
+
+  function handleNewMemberFormChange() {
+    const requiredInputs = document.querySelectorAll(
+      ".new_member input[required]"
+    );
+    const submitButton = document.querySelector('button[type="submit"]');
+
+    const hasValue = (input) => !!input.value.length;
+    const isComplete = (inputEls) => [...inputEls].every(hasValue);
+
+    submitButton.disabled = !isComplete(requiredInputs);
+  }
+
+  ["keyup", "change", "paste"].forEach((eventType) =>
+    newMemberForm.addEventListener(eventType, handleNewMemberFormChange)
+  );
+
+  // init submit button on page load
+  handleNewMemberFormChange();
+});

--- a/app/views/group_memberships/_form.html.erb
+++ b/app/views/group_memberships/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_tag(group_members_path, remote: true, method: 'post', id: 'search-form', class: 'new_member') do %>
     <div class="input-wrapper new-member-wrapper">
       <%= label_tag :people_search, t('views.group_memberships.index.form.add_someone') %>
-      <%= text_field_tag 'people_search', nil, class: 'form-control' %>
+      <%= text_field_tag 'people_search', nil, class: 'form-control', required: true %>
       <span id="searchHelpInline" class="text-muted">
         <%= t('views.group_memberships.index.form.help') %>.
       </span>
@@ -11,7 +11,7 @@
     </div>
       <%= button_tag type: "submit", class: 'btn btn-primary add-new-group-member', data: { confirm: t('views.group_memberships.index.form.submit_confirm') } do %>
         <i class="fa fa-plus-circle"></i>
-        <%= t('views.group_memberships.index.form.submit') %>
+  <%= t('views.group_memberships.index.form.submit') %>
       <% end %>
   <% end %>
 </div>

--- a/spec/features/group_membership_spec.rb
+++ b/spec/features/group_membership_spec.rb
@@ -51,6 +51,7 @@ describe 'groups members index page' do
       it 'adding should increase the user count of the group by 1' do
         expect do
           js_make_all_inputs_visible
+          fill_in('Add a new member', with: 'test-user')
           find("#uid", visible: false).set '5scyi59j8'
           click_button 'Add'
           click_button 'Confirm'
@@ -82,8 +83,6 @@ describe 'groups members index page' do
         # the button should now be disabled again
         expect(page).to have_button('Add member', disabled: true)
       end
-
-      it 'displays error if a bad username is submitted'
     end
   end
 end


### PR DESCRIPTION
This prevents a user from submitting the add new member form if the input is blank.

- Sets a `required` attribute is set on the input field.
- Using JS, check that `required` inputs have some value. If not, the submit button is disabled.
- Adds tests for this case.
- Fixes a test where the hidden input was set, but not the required input.

Closes #10.