### PR TITLE
Fix 500 error when accessing move_to_group/new

### DIFF
--- a/app/controllers/move_to_group_controller.rb
+++ b/app/controllers/move_to_group_controller.rb
@@ -1,4 +1,7 @@
 class MoveToGroupController < ApplicationController
+  before_action :ensure_signed_in
+  rescue_from "ActionController::UnknownFormat", with: :render_not_found
+
   def new
     @urls = Url
             .where(keyword: params[:keywords])
@@ -6,7 +9,6 @@ class MoveToGroupController < ApplicationController
     @groups = current_user.groups
 
     respond_to do |format|
-      format.html
       format.js { render 'move_to_group/new', layout: false }
     end
   end

--- a/spec/features/move_group_spec.rb
+++ b/spec/features/move_group_spec.rb
@@ -13,6 +13,14 @@ describe 'moving urls to a group', js: true do
     @user.groups << @other_group
   end
 
+  describe 'accessing html endpoints directly' do
+    it 'sends direct html visits to move_to_group/new to not found page' do
+      # dont give a 500 error for a missing template
+      visit new_move_to_group_path
+      expect(page).to have_content('Not Found')
+    end
+  end
+
   describe 'page with no urls' do
     it 'has a disabled bulk action button' do
       visit urls_path
@@ -45,7 +53,7 @@ describe 'moving urls to a group', js: true do
       find('.table-options').click
       click_link 'Move to a different collection'
 
-      expect(page).to have_selector('#index-modal', visible: true)
+      expect(page).to have_selector('#index-modal')
     end
 
     it 'moves the url immediately upon confirming' do


### PR DESCRIPTION
There is no html page template for move_to_group/new, only the js modal.

For now:

1. Make sure that the user is signed in so that
current_user exists.

2. remove html rendering attempt and handle unknown format with 404

Resolves #23.