### PR TITLE
Download QR code as SVG or PNG

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,10 +61,8 @@ gem 'data-confirm-modal', "~> 1.6"
 # use papertrail for auding or versioning
 gem 'paper_trail', "~> 14.0"
 
-# Use barby to generate QR codes
-gem 'barby', "~> 0.6"
-gem 'chunky_png', "~> 1.3"
-gem 'rqrcode', "~> 1.1"
+# QR code generation
+gem 'rqrcode', "~> 2.2"
 
 # authorization lugin
 gem 'pundit', "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,6 @@ GEM
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
     awesome_print (1.9.2)
-    barby (0.6.8)
     bcrypt_pbkdf (1.1.0)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
@@ -356,10 +355,10 @@ GEM
     request_store (1.5.1)
       rack (>= 1.4)
     rexml (3.2.5)
-    rqrcode (1.2.0)
+    rqrcode (2.2.0)
       chunky_png (~> 1.0)
-      rqrcode_core (~> 0.2)
-    rqrcode_core (0.2.0)
+      rqrcode_core (~> 1.0)
+    rqrcode_core (1.2.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -475,6 +474,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -482,7 +482,6 @@ DEPENDENCIES
   ajax-datatables-rails (~> 1.4)
   annotate (~> 3.1)
   awesome_print (~> 1.8)
-  barby (~> 0.6)
   bcrypt_pbkdf (~> 1.1)
   better_errors (~> 2.7)
   binding_of_caller (~> 1.0)
@@ -494,7 +493,6 @@ DEPENDENCIES
   capistrano-passenger (~> 0.2)
   capistrano-rails (~> 1.5)
   capistrano-rbenv (~> 2.1)
-  chunky_png (~> 1.3)
   clipboard-rails (~> 1.7)
   coffee-rails (~> 4.2)
   cypress-on-rails (~> 1.0)
@@ -530,7 +528,7 @@ DEPENDENCIES
   pundit (~> 2.1)
   rack-utf8_sanitizer (~> 1.7)
   rails (~> 7.0)
-  rqrcode (~> 1.1)
+  rqrcode (~> 2.2)
   rspec-rails (~> 6.0.0)
   rspec-retry (~> 0.6)
   rubocop (~> 1.18)

--- a/README.md
+++ b/README.md
@@ -110,22 +110,6 @@ See [Deploying to Production](./deploy_to_production.md).
 
 After deploying, populate the ip2location_db1 table with the content from the [IP2Location LITE IP-Country Database](https://lite.ip2location.com/database/ip-country).
 
-## Tech Stack
-
-- Rails
-- Vue
-- MySQL
-- LDAP (for directory lookup)
-- [OmniAuth](https://github.com/omniauth/omniauth), for authentication
-- [Pundit](https://github.com/elabs/pundit), for authorization
-- [Paper trail](https://github.com/airblade/paper_trail), for URL version history
-- [Turbolinks](https://github.com/turbolinks/turbolinks), for faster browsing
-- [Typeahead](https://github.com/twitter/typeahead.js/), for user autocomplete
-- [Google Charts](https://developers.google.com/chart/), for click visualization
-- [Barby](https://github.com/toretore/barby), for QR code generation
-- [Rubocop](https://github.com/bbatsov/rubocop), to enforce best practices
-- [Starburst](https://github.com/csm123/starburst), for in-app announcements
-
 ## Internationalization
 
 Most of the language has been extracted into a [single localization file](https://github.umn.edu/latis-sw/z/blob/develop/config/locales/en.bootstrap.yml). This allows you to change any language and make Z applicable to your environment.

--- a/app/assets/javascripts/urls.js
+++ b/app/assets/javascripts/urls.js
@@ -386,7 +386,7 @@ $(document).ready(function() {
     $(document).on("click", ".url-blurb-close-button", function(e) {
         e.preventDefault();
         $(this).closest(".url-blurb")
-            .addClass("off")
+            .addClass("off tw-overflow-hidden")
             .on("transitionend webkitTransitionEnd oTransitionEnd otransitionend MSTransitionEnd", function() {
                 $(this).remove();
             });

--- a/app/assets/javascripts/urls.js
+++ b/app/assets/javascripts/urls.js
@@ -378,15 +378,11 @@ $(document).ready(function() {
     $(document).on("click", ".share-url", function(e) {
         e.preventDefault();
     });
-    $(document).on("click", ".url-share-button-twitter", function(e) {
+    $(document).on("click", ".js-share-button-twitter", function(e) {
         e.preventDefault();
         var shortUrl = $(this).data("shortUrl");
         window.open("https://twitter.com/intent/tweet?text=" + shortUrl, '', 'menubar=no, toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');
     })
-    $(document).on("click", ".url-share-button-qr", function(e) {
-        e.preventDefault();
-        window.location = $(this).data("path");
-    });
     $(document).on("click", ".url-blurb-close-button", function(e) {
         e.preventDefault();
         $(this).closest(".url-blurb")

--- a/app/assets/stylesheets/urls.scss
+++ b/app/assets/stylesheets/urls.scss
@@ -326,188 +326,11 @@ table.dataTable tr.selected .fa-ellipsis-h {
   }
 }
 
-// $superInputHeight: 50px;
-// .super-input {
-//   display: table;
-//   width: 100%;
-//   overflow: hidden;
-//   height: 50px;
-//   position: relative;
-//   margin: 0;
-//   background-color: white;
-//   color: black;
-//   > * {
-//     display: inline-block;
-//     vertical-align: middle;
-//   }
-
-//   input {
-//     background: white;
-//     border: none;
-//     font-size: 14px;
-//     height: $superInputHeight;
-//     padding: 0 30px;
-//     margin: 0;
-//   }
-//   input:focus {
-//     outline: none;
-//   }
-//   span {
-//     display: block;
-//     overflow: hidden;
-//   }
-//   .super-input-right {
-//     width: 1px;
-//     white-space: nowrap;
-//     display: table-cell;
-//   }
-
-//   .super-input-right > * {
-//     display: inline-block;
-//   }
-//   .divider {
-//     height: 40%;
-//     width: 1px;
-//     background-color: #ddd;
-//     margin: 0 15px;
-//   }
-
-//   button {
-//     height: $superInputHeight;
-//     margin: 0;
-//     border: 0;
-//     padding: 0 30px;
-//     color: white;
-//     font-weight: 600;
-//     background-color: $primaryColor;
-//     font-size: 13px;
-//     font-weight: 500;
-//   }
-// }
-
-// .super-input {
-//   .js-new-url-url,
-//   .js-new-group-name {
-//     width: 100%;
-//     display: table-cell;
-//   }
-//   .keyword-wrapper,
-//   .description-wrapper {
-//     height: $superInputHeight;
-//     > * {
-//       display: inline-block;
-//     }
-
-//     .keyword-static-text,
-//     .description-static-text {
-//       font-weight: 500;
-//       color: #555;
-//     }
-//     .field_with_errors {
-//       height: 100%;
-//     }
-//     input {
-//       padding-left: 0;
-//       width: 175px;
-//       height: 100%;
-//       margin-top: -0.5px;
-//     }
-//   }
-// }
-// @media screen and (min-width: 1100px) {
-//   .super-input {
-//     .keyword-wrapper,
-//     .description-wrapper {
-//       input.js-new-url-keyword,
-//       input.js-new-group-description {
-//         width: 300px;
-//       }
-//     }
-//   }
-// }
-// @media screen and (max-width: 992px) {
-//   .super-input {
-//     .js-new-url-url,
-//     .js-new-group-name {
-//       width: 200px;
-//     }
-//   }
-// }
-// @media screen and (max-width: 640px) {
-//   .url-banner-title {
-//     text-align: center;
-//   }
-//   #url-blurb-container {
-//     display: none;
-//   }
-//   .cancel-edit {
-//     display: block !important;
-//     margin-top: 10px !important;
-//   }
-//   #new-url-form {
-//     height: 240px;
-
-//     .z-hero-title {
-//       text-align: center;
-//     }
-//     form {
-//       width: 100%;
-//     }
-//   }
-//   .z-hero-content {
-//     width: 90%;
-//   }
-//   .z-hero {
-//     .z-hero-content {
-//       .z-hero-title-large {
-//         font-size: 40px;
-//       }
-//     }
-//   }
-
-//   .super-input {
-//     height: auto;
-//     width: 100%;
-//     display: block;
-//     overflow: auto;
-//     .super-input-right {
-//       display: block;
-//       width: auto;
-//       white-space: initial;
-//       .divider {
-//         display: none;
-//       }
-//     }
-//     > * {
-//       display: block;
-//     }
-//     .js-new-url-url,
-//     .js-new-group-name {
-//       width: 100%;
-//       border-bottom: 1px solid #eee;
-//     }
-//     .keyword-wrapper {
-//       width: 100%;
-//       padding: 0 30px;
-//       white-space: nowrap;
-//       text-align: left;
-//       input {
-//         width: auto !important;
-//         height: $superInputHeight;
-//         padding: 0;
-//       }
-//     }
-//     button {
-//       width: 100%;
-//     }
-//   }
-// }
-
 .url-blurb {
   transition: height 0.3s, padding 0.3s;
   border-top: 1px solid #cfcfcf;
+  border-radius: 5px;
   width: 100%;
-  height: 55px;
   background-color: white;
   padding: 10px 20px;
   box-sizing: border-box;
@@ -532,11 +355,8 @@ table.dataTable tr.selected .fa-ellipsis-h {
   .url-blurb-close-button {
     background: none;
     border: none;
-    float: right;
     border-radius: 100%;
     font-size: 12px;
-    margin-top: 7px;
-    margin-left: 20px;
     opacity: 0.6;
     &:hover {
       opacity: 1;
@@ -544,7 +364,6 @@ table.dataTable tr.selected .fa-ellipsis-h {
   }
 
   .url-blurb-actions {
-    float: right;
     .url-blurb-actions-header {
       font-size: 9px;
       text-transform: uppercase;

--- a/app/assets/stylesheets/urls.scss
+++ b/app/assets/stylesheets/urls.scss
@@ -649,20 +649,10 @@ table.dataTable tr.selected .fa-ellipsis-h {
       &.url-share-button-qr {
         color: black;
         font-size: 13px;
-        i.fa::before {
-          font-size: 13px;
-          color: black;
-        }
       }
     }
   }
   i.fa {
-    &::before {
-      font-size: 12px;
-      color: white;
-      padding-right: 10px;
-      vertical-align: middle;
-    }
     &.fa-ellipsis-h {
       &::before {
         color: #888;

--- a/app/assets/stylesheets/urls.scss
+++ b/app/assets/stylesheets/urls.scss
@@ -334,7 +334,6 @@ table.dataTable tr.selected .fa-ellipsis-h {
   background-color: white;
   padding: 10px 20px;
   box-sizing: border-box;
-  overflow: hidden;
   color: black;
   &.off {
     height: 0;

--- a/app/controllers/url_barcodes_controller.rb
+++ b/app/controllers/url_barcodes_controller.rb
@@ -1,9 +1,3 @@
-# controllers/url_barcodes_controller.rb
-require 'barby'
-require 'barby/barcode/qr_code'
-require 'barby/outputter/png_outputter'
-require 'barby/outputter/svg_outputter'
-
 class UrlBarcodesController < ApplicationController
   def show
     @url = Url.find_by(keyword: params[:url_id])

--- a/app/controllers/url_barcodes_controller.rb
+++ b/app/controllers/url_barcodes_controller.rb
@@ -28,7 +28,7 @@ class UrlBarcodesController < ApplicationController
     when 'svg'
       outputter = Barby::SvgOutputter.new(qrcode)
       outputter.xdim = 10
-      outputter.background = 'transparent'
+      outputter.background = "none"
       outputter.to_svg
     else
       outputter = Barby::PngOutputter.new(qrcode)

--- a/app/controllers/url_barcodes_controller.rb
+++ b/app/controllers/url_barcodes_controller.rb
@@ -1,3 +1,5 @@
+require 'barby'
+require 'barby/barcode/qr_code'
 require 'barby/outputter/png_outputter'
 require 'barby/outputter/svg_outputter'
 

--- a/app/controllers/url_barcodes_controller.rb
+++ b/app/controllers/url_barcodes_controller.rb
@@ -2,19 +2,44 @@
 require 'barby'
 require 'barby/barcode/qr_code'
 require 'barby/outputter/png_outputter'
+require 'barby/outputter/svg_outputter'
 
 class UrlBarcodesController < ApplicationController
   def show
-    url = Url.find_by(keyword: params[:url_id])
-    if url.present?
-      authorize url
-      barcode = Barby::QrCode.new(view_context.full_url(url))
-      barcode_png = Barby::PngOutputter.new(barcode)
-      barcode_png.xdim = 10
+    @url = Url.find_by(keyword: params[:url_id])
+    return redirect_to root_path if @url.blank?
 
-      send_data barcode_png.to_png, filename: "z-#{url.keyword}.png"
+    authorize @url
+    format = (params[:format] || 'png').downcase
+
+    # validate format
+    return head :bad_request unless %w[png svg].include?(format)
+
+    data = generate_qrcode(@url, format)
+
+    send_data data, type: mime_type(format), filename: "z-#{@url.keyword}.#{format}"
+  end
+
+  private
+
+  def generate_qrcode(url, format)
+    qrcode = Barby::QrCode.new(view_context.full_url(url))
+
+    case format
+    when 'svg'
+      outputter = Barby::SvgOutputter.new(qrcode)
+      outputter.xdim = 10
+      outputter.background = 'transparent'
+      outputter.to_svg
     else
-      redirect_to root_path
+      outputter = Barby::PngOutputter.new(qrcode)
+      outputter.xdim = 10
+      outputter.to_png
     end
+  end
+
+  def mime_type(format)
+    types = { png: 'image/png', svg: 'image/svg+xml' }
+    types[format.to_sym]
   end
 end

--- a/app/controllers/url_barcodes_controller.rb
+++ b/app/controllers/url_barcodes_controller.rb
@@ -1,3 +1,6 @@
+require 'barby/outputter/png_outputter'
+require 'barby/outputter/svg_outputter'
+
 class UrlBarcodesController < ApplicationController
   def show
     @url = Url.find_by(keyword: params[:url_id])

--- a/app/controllers/url_barcodes_controller.rb
+++ b/app/controllers/url_barcodes_controller.rb
@@ -1,12 +1,13 @@
 # controllers/url_barcodes_controller.rb
+require 'barby'
+require 'barby/barcode/qr_code'
+require 'barby/outputter/png_outputter'
+
 class UrlBarcodesController < ApplicationController
   def show
     url = Url.find_by(keyword: params[:url_id])
     if url.present?
       authorize url
-      require 'barby'
-      require 'barby/barcode/qr_code'
-      require 'barby/outputter/png_outputter'
       barcode = Barby::QrCode.new(view_context.full_url(url))
       barcode_png = Barby::PngOutputter.new(barcode)
       barcode_png.xdim = 10

--- a/app/controllers/url_barcodes_controller.rb
+++ b/app/controllers/url_barcodes_controller.rb
@@ -1,8 +1,3 @@
-require 'barby'
-require 'barby/barcode/qr_code'
-require 'barby/outputter/png_outputter'
-require 'barby/outputter/svg_outputter'
-
 class UrlBarcodesController < ApplicationController
   def show
     @url = Url.find_by(keyword: params[:url_id])
@@ -22,18 +17,13 @@ class UrlBarcodesController < ApplicationController
   private
 
   def generate_qrcode(url, format)
-    qrcode = Barby::QrCode.new(view_context.full_url(url))
+    qrcode = RQRCode::QRCode.new(view_context.full_url(url))
 
     case format
     when 'svg'
-      outputter = Barby::SvgOutputter.new(qrcode)
-      outputter.xdim = 10
-      outputter.background = "none"
-      outputter.to_svg
+      qrcode.as_svg(viewbox: true)
     else
-      outputter = Barby::PngOutputter.new(qrcode)
-      outputter.xdim = 10
-      outputter.to_png
+      qrcode.as_png(size: 300, border_modules: 1)
     end
   end
 

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -24,14 +24,6 @@ class UrlsController < ApplicationController
   # GET /urls/1
   # GET /urls/1.json
   def show
-    require 'barby'
-    require 'barby/barcode/qr_code'
-    require 'barby/outputter/svg_outputter'
-
-    @barcode = Barby::QrCode.new(view_context.full_url(@url))
-    @barcode_svg = Barby::SvgOutputter.new(@barcode)
-    @barcode_svg.xdim = 5
-
     @url_identifier = @url.id
 
     @clicks = {
@@ -58,20 +50,20 @@ class UrlsController < ApplicationController
     end
   end
 
-  def edit
-    @url_identifier = @url.id
-
-    respond_to do |format|
-      format.html
-      format.js { render layout: false }
-    end
-  end
-
   # GET /urls/new
   def new
     @url = Url.new
     @url_identifier = Time.zone.now.to_ms
     respond_to do |format|
+      format.js { render layout: false }
+    end
+  end
+
+  def edit
+    @url_identifier = @url.id
+
+    respond_to do |format|
+      format.html
       format.js { render layout: false }
     end
   end
@@ -114,7 +106,7 @@ class UrlsController < ApplicationController
   # DELETE /urls/1.json
   def destroy
     if @url.destroy
-    respond_to do |format|
+      respond_to do |format|
         format.html { redirect_to urls_url, notice: 'URL was successfully destroyed.' }
         format.js { render layout: false }
         format.json { render json: { success: true, message: "Group deleted." } }

--- a/app/views/urls/_in_row_actions.html.erb
+++ b/app/views/urls/_in_row_actions.html.erb
@@ -24,16 +24,16 @@
         </a>
         <ul class="dropdown-menu dropdown-menu-left">
           <li>
-            <button class="url-share-button url-share-button-qr js-qrcode-download tw-text-left" data-path="<%= url_download_qrcode_path(url.keyword) %>">
+            <a class="tw-text-left !tw-flex tw-justify-between tw-items-baseline" href="<%= url_download_qrcode_path(url.keyword) %>" download>
               PNG
-              <span class="tw-text-neutral-400 tw-text-xs">(default)</span>
-            </button>
+              <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400">Standard</span>
+            </a>
           </li>
           <li>
-            <button class="url-share-button url-share-button-qr js-qrcode-download tw-text-left" data-path="<%= url_download_qrcode_path(url.keyword, format: :svg) %>">
+            <a class="tw-text-left !tw-flex tw-justify-between tw-items-baseline" href="<%= url_download_qrcode_path(url.keyword, format: :svg) %>" download>
               SVG
-              <span class="tw-text-neutral-400 tw-text-xs">(advanced)</span>
-            </button>
+              <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400">Advanced</span>
+            </a>
           </li>
         </ul>
       </li>

--- a/app/views/urls/_in_row_actions.html.erb
+++ b/app/views/urls/_in_row_actions.html.erb
@@ -11,10 +11,12 @@
                   class: 'btn action-button share-url fa fa-share-square-o',
                   'data-content': render('urls/share_buttons', url: url) %>
         <ul class="dropdown-menu dropdown-menu-left">
-          <button class="url-share-button url-share-button-twitter" data-short-url="<%= full_url(url) %>">
-            <i class="fa fa-twitter"></i>
-            <%= t("views.urls.index.table.in_row_actions.twitter") %>
-          </button>
+          <li>
+            <button class="url-share-button js-share-button-twitter tw-text-twitter-blue !tw-text-sm" data-short-url="<%= full_url(url) %>">
+              <i class="fa fa-twitter"></i>
+              <%= t("views.urls.index.table.in_row_actions.twitter") %>
+            </button>
+          </li>
         </ul>
       </li>
       <li class="dropdown-submenu pull-left">
@@ -42,7 +44,7 @@
                     url_path(url.keyword),
                     class: 'btn action-button show-url fa fa-bar-chart' %>
       </li>
-        <% if admin_view %>
+      <% if admin_view %>
         <li>
           <%= link_to t('views.urls.index.table.in_row_actions.edit'),
                       edit_admin_url_path(url),
@@ -55,7 +57,7 @@
                       data: { confirm: t('views.urls.index.table.in_row_actions.delete_confirm', keyword: url.keyword) },
                       class: 'btn action-button delete-url fa fa-trash-o', remote: true %>
         </li>
-        <% else %>
+      <% else %>
         <li>
           <%= link_to t('views.urls.index.table.in_row_actions.edit'),
                       edit_url_path(url),
@@ -68,8 +70,7 @@
                       data: { confirm: t('views.urls.index.table.in_row_actions.delete_confirm', keyword: url.keyword) },
                       class: 'btn delete-url fa fa-trash-o', remote: true %>
         </li>
-        <% end %>
+      <% end %>
     </ul>
   </div>
-
 </div>

--- a/app/views/urls/_in_row_actions.html.erb
+++ b/app/views/urls/_in_row_actions.html.erb
@@ -14,7 +14,25 @@
           <%= render('urls/share_buttons', url: url, list: true) %>
         </ul>
       </li>
-
+      <li class="dropdown-submenu pull-left">
+        <a href="#" class="btn action-button">
+          <i class="fa fa-qrcode !tw-text-black"></i>
+          <%= t('views.urls.index.table.in_row_actions.qr_code') %>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-left">
+          <li>
+            <button class="url-share-button url-share-button-qr js-qrcode-download tw-text-left" data-path="<%= url_download_qrcode_path(url.keyword) %>">
+              PNG
+              <span class="tw-text-neutral-400 tw-text-xs">(default)</span>
+            </button>
+          </li>
+          <li>
+            <button class="url-share-button url-share-button-qr js-qrcode-download tw-text-left" data-path="<%= url_download_qrcode_path(url.keyword, format: :svg) %>">
+              SVG
+            </button>
+          </li>
+        </ul>
+      </li>
       <li>
         <%= link_to t('views.urls.index.table.in_row_actions.stats'),
                     url_path(url.keyword),

--- a/app/views/urls/_in_row_actions.html.erb
+++ b/app/views/urls/_in_row_actions.html.erb
@@ -32,6 +32,7 @@
           <li>
             <button class="url-share-button url-share-button-qr js-qrcode-download tw-text-left" data-path="<%= url_download_qrcode_path(url.keyword, format: :svg) %>">
               SVG
+              <span class="tw-text-neutral-400 tw-text-xs">(advanced)</span>
             </button>
           </li>
         </ul>

--- a/app/views/urls/_in_row_actions.html.erb
+++ b/app/views/urls/_in_row_actions.html.erb
@@ -11,7 +11,10 @@
                   class: 'btn action-button share-url fa fa-share-square-o',
                   'data-content': render('urls/share_buttons', url: url) %>
         <ul class="dropdown-menu dropdown-menu-left">
-          <%= render('urls/share_buttons', url: url, list: true) %>
+          <button class="url-share-button url-share-button-twitter" data-short-url="<%= full_url(url) %>">
+            <i class="fa fa-twitter"></i>
+            <%= t("views.urls.index.table.in_row_actions.twitter") %>
+          </button>
         </ul>
       </li>
       <li class="dropdown-submenu pull-left">

--- a/app/views/urls/_share_buttons.html.erb
+++ b/app/views/urls/_share_buttons.html.erb
@@ -1,21 +1,24 @@
-<% is_large = (defined?(large) && large == true) ? 'url-share-button-large' : '' %>
-<% is_list = (defined?(list) && list == true) ? true : false %>
-
-<% if is_list %>
-  <li>
-<% end %>
-  <button class="url-share-button url-share-button-twitter <%= is_large %>" data-short-url="<%= full_url(url) %>">
-    <i class="fa fa-twitter"></i>
-    <%= t('views.urls.index.table.in_row_actions.tweet') %>
-  </button>
-<% if is_list %>
-  </li>
-  <li>
-<% end %>
-  <button class="url-share-button url-share-button-qr <%= is_large %> js-qrcode-download" data-path="<%= url_download_qrcode_path(url.keyword) %>">
+<% 
+  is_large = (defined?(large) && large == true) ? 'btn-lg' : 'btn-sm' 
+  qrcode_url_png = url_download_qrcode_path(url.keyword)
+  qrcode_url_svg = url_download_qrcode_path(url.keyword) + '.svg'
+%>
+<button class="btn btn-default tw-border-twitter-blue tw-text-twitter-blue js-share-button-twitter hover:tw-bg-twitter-blue hover:tw-text-white hover:tw-border-twitter-blue <%= is_large %>" data-short-url="<%= full_url(url) %>">
+  <i class="fa fa-twitter"></i>
+  <%= t('views.urls.index.table.in_row_actions.tweet') %>
+</button>
+<!-- QR Code split download button -->
+<div class="btn-group">
+  <a href="<%= qrcode_url_png %>" class="btn btn-default <%= is_large %> " download>
     <i class="fa fa-qrcode"></i>
     <%= t('views.urls.index.table.in_row_actions.qr_code') %>
+  </a>
+  <button type="button" class="btn btn-default dropdown-toggle  <%= is_large %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <span class="caret"></span>
+    <span class="sr-only">Toggle Dropdown</span>
   </button>
-<% if is_list %>
-  </li>
-<% end %>
+  <ul class="dropdown-menu">
+    <li><a href="<%= qrcode_url_png %>" download>PNG</a></li>
+    <li><a href="<%= qrcode_url_svg %>" download>SVG</a></li>
+  </ul>
+</div>

--- a/app/views/urls/_share_buttons.html.erb
+++ b/app/views/urls/_share_buttons.html.erb
@@ -1,7 +1,5 @@
 <% 
   is_large = (defined?(large) && large == true) ? 'btn-lg' : 'btn-sm' 
-  qrcode_url_png = url_download_qrcode_path(url.keyword)
-  qrcode_url_svg = url_download_qrcode_path(url.keyword) + '.svg'
 %>
 <button class="btn btn-default tw-border-twitter-blue tw-text-twitter-blue js-share-button-twitter hover:tw-bg-twitter-blue hover:tw-text-white hover:tw-border-twitter-blue <%= is_large %>" data-short-url="<%= full_url(url) %>">
   <i class="fa fa-twitter"></i>
@@ -9,7 +7,7 @@
 </button>
 <!-- QR Code split download button -->
 <div class="btn-group">
-  <a href="<%= qrcode_url_png %>" class="btn btn-default <%= is_large %> " download>
+  <a href="<%= url_download_qrcode_path(url.keyword) %>" class="btn btn-default <%= is_large %> " download>
     <i class="fa fa-qrcode"></i>
     <%= t('views.urls.index.table.in_row_actions.qr_code') %>
   </a>
@@ -18,7 +16,17 @@
     <span class="sr-only">Toggle Dropdown</span>
   </button>
   <ul class="dropdown-menu">
-    <li><a href="<%= qrcode_url_png %>" download>PNG</a></li>
-    <li><a href="<%= qrcode_url_svg %>" download>SVG</a></li>
+    <li>
+      <a href="<%= url_download_qrcode_path(url.keyword) %>" download class="!tw-flex tw-justify-between tw-items-baseline">
+        PNG 
+        <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400">Standard</span>
+      </a>
+    </li>
+    <li>
+      <a href="<%= url_download_qrcode_path(url.keyword, format: :svg) %>" download class="!tw-flex tw-justify-between tw-items-baseline">
+        SVG 
+        <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400">Advanced</span>
+      </a>
+    </li>
   </ul>
 </div>

--- a/app/views/urls/_url_blurb.html.erb
+++ b/app/views/urls/_url_blurb.html.erb
@@ -1,16 +1,4 @@
-<div class="url-blurb">
-  <button class="url-blurb-close-button">
-    <i class="fa fa-close"> </i>
-  </button>
-  <div class="url-blurb-actions">
-    <div class="url-blurb-actions-header">
-        share your new z link
-    </div>
-    <div class="url-blurb-action-buttons">
-        <%= render 'share_buttons', url: @url %>
-    </div>
-  </div>
-
+<div class="url-blurb tw-flex tw-justify-between tw-items-center">
   <div class="url-blurb-details">
     <div class="url-blurb-source">
       <%= display_long_url(@url.url,75) %>
@@ -23,4 +11,18 @@
       </button>
     </div>
   </div>
+  <div class="tw-flex tw-items-center tw-gap-4">
+    <div class="url-blurb-actions">
+      <div class="url-blurb-actions-header">
+        share your new z link
+      </div>
+      <div class="url-blurb-action-buttons">
+        <%= render 'share_buttons', url: @url %>
+      </div>
+    </div>
+    <button class="url-blurb-close-button">
+      <i class="fa fa-close"> </i>
+    </button>
+  </div>
+</div>
 </div>

--- a/cypress/e2e/urlsPageListZlinks.cy.ts
+++ b/cypress/e2e/urlsPageListZlinks.cy.ts
@@ -264,11 +264,11 @@ describe("urlsPageListZlinks - /shortener/urls", () => {
 
         // hover over the share item to open the share submenu
         cy.get("@claDropdown")
-          .contains("Share")
+          .contains("QR Code")
           .realHover()
           .then(() => {
             // click on the QR Code item
-            cy.get("@claDropdown").contains("QR Code").click();
+            cy.get("@claDropdown").contains("PNG").click();
           });
 
         // wait for the download to complete and then validate

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -24,6 +24,7 @@ module.exports = {
         "umn-neutral-700": `#5a5a5a`, // text color
         "umn-neutral-800": `#262626`, // active text color
         "umn-neutral-900": `#1a1a1a`,
+        "twitter-blue": "#51adec",
       },
     },
   },


### PR DESCRIPTION
Adds an option to download a QR code as an SVG.

Currently, QR codes download as a PNG with a white background. This works fine for basic use cases, but designers usually prefer an SVG format to make it easier to scale and colorize.

- added QR Code submenu with two options for download: "PNG (default)" and "SVG".
- moved QR Code out of the Share submenu in order to prevent overly nested submenus.
- updated QR code controller endpoint to take a format parameter: `/shortener/urls/:short_code/download_qrcode.svg`
- removed some css with high specificity that was difficult to style around since it target font-awesome's `:before` element directly.
- moved `require` statements that were in the controller. My understanding is that putting these in the controller causes them to be invoked on every request, rather than when the class is loaded.  I've only seen `require` statements at the top... (and even that's rare given that the rails autoloader should take care of most things).

## Screenshots
![ScreenShot 2024-04-17 at 17 16 45@2x](https://github.com/UMN-LATIS/z/assets/980170/d69ac331-309f-4f67-be9b-654a6315691a)

Example SVG QR Code with transparent background (beware dark mode users):
![z-5no1](https://github.com/UMN-LATIS/z/assets/980170/0dad04a3-0a14-4263-b2d8-c67dda969fbe)

On <https://cla-z-dev-02.oit.umn.edu> for testing

Resolves #157, #152 