### PR TITLE
Add api endpoints updating and showing a zlink

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::BaseController < ActionController::Base
     # head(:unauthorized) && return unless request.headers['Authorization']
 
     # Parse Auth Header
-    user_uid, token = request.headers['Authorization'].split(':')
+    user_uid, token = request.headers['Authorization']&.split(':')
     head(:unauthorized) && return unless user_uid && token
 
     # Load User

--- a/app/controllers/api/v1/urls_controller.rb
+++ b/app/controllers/api/v1/urls_controller.rb
@@ -1,4 +1,26 @@
 class Api::V1::UrlsController < Api::V1::BaseController
+  def show
+    # the `id` param actually the keyword
+    keyword = params[:id]
+
+    # get the url with the keyword
+    url = Url.find_by(keyword:)
+
+    # if there's no url, return 404
+    if url.blank?
+      render json: { status: :error, message: 'URL not found' }, status: :not_found
+      return
+    end
+
+    # if the url's group doesn't have the current user as a member
+    # then return 403
+    if url.group.users.exclude?(@current_user)
+      render json: { status: :error, message: 'Unauthorized access' }, status: :forbidden
+      return
+    end
+
+    render json: { status: :success, message: url }
+  end
   def create
     urls = @payload['urls']
 

--- a/app/controllers/api/v1/urls_controller.rb
+++ b/app/controllers/api/v1/urls_controller.rb
@@ -21,6 +21,7 @@ class Api::V1::UrlsController < Api::V1::BaseController
 
     render json: { status: :success, message: url }
   end
+
   def create
     urls = @payload['urls']
 
@@ -36,7 +37,7 @@ class Api::V1::UrlsController < Api::V1::BaseController
         group_id = @current_user.default_group_id
       end
 
-      new_url = Url.new(url: url['url'], keyword: url['keyword'], group_id: group_id)
+      new_url = Url.new(url: url['url'], keyword: url['keyword'], group_id:)
 
       url['result'] =
         if new_url.save
@@ -47,5 +48,36 @@ class Api::V1::UrlsController < Api::V1::BaseController
     end
 
     render json: urls
+  end
+
+  def update
+    current_keyword = params[:id]
+
+    url = Url.find_by(keyword: current_keyword)
+
+    # if there's no url, return 404
+    if url.blank?
+      render json: { status: :error, message: 'URL not found' }, status: :not_found
+      return
+    end
+
+    # if the url's group doesn't have the current user as a member
+    # then return 403
+    if url.group.users.exclude?(@current_user)
+      render json: { status: :error, message: 'Unauthorized access' }, status: :forbidden
+      return
+    end
+
+    # don't permit keyword changes
+    if @payload['keyword'] && @payload['keyword'] != current_keyword
+      render json: { status: :error, message: 'Cannot change keyword' }, status: :bad_request
+      return
+    end
+
+    # update url with payload
+    url.url = @payload['url']
+    url.save
+
+    render json: { status: :success, message: url }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   # Handle API
   namespace :api do
     namespace :v1 do
-      resources :urls, only: [:create]
+      resources :urls, only: %i[create show update]
     end
   end
 

--- a/spec/apis/urls_spec.rb
+++ b/spec/apis/urls_spec.rb
@@ -177,4 +177,61 @@ describe '[API: URLs]', type: :api do
     end
   end
 
+  describe 'PUT /api/v1/urls/:keyword' do
+    let(:user) { create(:user) }
+    let(:existing_url) { create(:url, group_id: user.default_group_id, keyword: 'unique-keyword', url: 'http://example.com') }
+
+    it 'updates a URL' do
+      new_url = 'http://example.org'
+
+      payload = { url: new_url, keyword: existing_url.keyword }
+      token = JWT.encode payload, user.secret_key, 'HS256'
+
+      header 'Authorization', "#{user.uid}:#{token}"
+
+      put "/api/v1/urls/#{existing_url.keyword}"
+      expect(last_response.status).to eq(200)
+      result = JSON.parse(last_response.body)
+
+      expect(result['status']).to eq('success')
+      expect(result['message']['url']).to eq(payload[:url])
+      expect(result['message']['keyword']).to eq(payload[:keyword])
+    end
+
+    it 'returns a 404 when the URL does not exist' do
+      new_url = 'http://example.org'
+
+      payload = { url: new_url, keyword: 'nonexistent-keyword' }
+      token = JWT.encode payload, user.secret_key, 'HS256'
+
+      header 'Authorization', "#{user.uid}:#{token}"
+
+      put "/api/v1/urls/#{payload[:keyword]}"
+      expect(last_response.status).to eq(404)
+      result = JSON.parse(last_response.body)
+      expect(result['status']).to eq('error')
+      expect(result['message']).to eq('URL not found')
+    end
+
+    it 'does not permit keyword updates' do
+      new_keyword = 'new-keyword'
+
+      payload = { url: existing_url.url, keyword: new_keyword }
+      token = JWT.encode payload, user.secret_key, 'HS256'
+
+      header 'Authorization', "#{user.uid}:#{token}"
+
+      put "/api/v1/urls/#{existing_url.keyword}"
+      expect(last_response.status).to eq(400)
+      result = JSON.parse(last_response.body)
+
+      expect(result['status']).to eq('error')
+      expect(result['message']).to eq('Cannot change keyword')
+
+      # verify that the keyword is not updated
+      url = Url.find(existing_url.id)
+      expect(url.keyword).to eq(existing_url.keyword)
+      expect(url.url).to eq(existing_url.url)
+    end
+  end
 end

--- a/spec/apis/urls_spec.rb
+++ b/spec/apis/urls_spec.rb
@@ -116,5 +116,23 @@ describe '[API: URLs]', type: :api do
 
       expect(last_response.status).to be(401)
     end
+
+    it 'does not permit users to create urls for other users' do
+      mallory = create(:user, { uid: 'mallory' })
+      alice = create(:user, { uid: 'alice' })
+
+      # mallory creates a URL for alice
+      payload = { urls: [{ url: url1_url }] }
+
+      # and then signs it with her own (mallory's) secret key
+      token = JWT.encode payload, mallory.secret_key, 'HS256'
+
+      # but then tries to use alice's uid to create
+      # urls on her behalf
+      header 'Authorization', "#{alice.uid}:#{token}"
+      post '/api/v1/urls'
+
+      expect(last_response.status).to be(401)
+    end
   end
 end


### PR DESCRIPTION
Adds:
- `GET /api/v1/urls/:keyword`
- `PUT /api/v1/urls/:keyword`

Notes:
- Users can only update the zlink destination url, which I think is the most typical usecase. Keyword updates are not allowed in this PR. 
- This continues with the existing signed payload in header approach that the `create` method uses.
- Api docs will also need an update, but I'll do that in a separate PR if this approach looks good.

Closes #161 

On dev for testing.