### PR TITLE
fix bottom padding on error page

### DIFF
--- a/app/assets/stylesheets/_error-page.scss
+++ b/app/assets/stylesheets/_error-page.scss
@@ -3,6 +3,7 @@
   --maroon: #7a0019;
   color: var(--black);
   line-height: 1.4;
+  padding: 6rem 1rem;
 }
 
 .error-page a {
@@ -14,17 +15,9 @@
   line-height: inherit;
 }
 
-.error-page__image {
-  display: block;
-  margin: 1rem auto 3rem;
-  width: 50%;
-  min-width: 12rem;
-  max-width: 30rem;
-}
 
 .error-page__heading {
   font-size: 6rem;
-  margin-top: 4rem;
   margin-bottom: 1rem;
 }
 
@@ -48,5 +41,8 @@
   }
   .error-page__message {
     font-size: 1rem;
+  }
+  .error-page {
+    padding: 3rem 1rem;
   }
 }


### PR DESCRIPTION
- remove css for error page image, as there isn't any 😢
- add padding on error page and remove margin on header

Before
<img src="https://github.com/UMN-LATIS/z/assets/980170/98ed677b-5b69-4ade-8142-fbe745b022c8" width="400">

After
<img src="https://github.com/UMN-LATIS/z/assets/980170/6962a255-bbf0-4fbc-974c-3dc6f6252837" width="400">
