### PR TITLE
fix: missing callback ActionNotFound exception

### DIFF
--- a/app/controllers/transfer_requests_controller.rb
+++ b/app/controllers/transfer_requests_controller.rb
@@ -1,6 +1,6 @@
 class TransferRequestsController < ApplicationController
   before_action :set_transfer_request,
-                only: %i[edit update destroy show confirm]
+                only: %i[destroy confirm]
   def index
     @transfer_requests_to =
       TransferRequest.where(to_group_id: current_user.id)


### PR DESCRIPTION
This fixes a missing callback action error:

```
AbstractController::ActionNotFound - The edit action could not be found for the :set_transfer_request
callback on TransferRequestsController, but it is listed in the controller's
:only option.
Raising for missing callback actions is a new default in Rails 7.1, if you'd
like to turn this off you can delete the option from the environment configurations
or set `config.action_controller.raise_on_missing_callback_actions` to `false`.
```

We're ignoring this default in production environments, but kept it enabled in dev and test so that we can fix errors as they arise.

`edit`, `update`, and `show` mehtods don't exist on this controller, so they're removed from the `before_action`.