### PR TITLE
when viewing collection, add new zlink to said collection

### DIFF
--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -3,9 +3,7 @@ class UrlsController < ApplicationController
   before_action :ensure_signed_in
   before_action :set_url, only: %i[edit update destroy]
   before_action :set_url_friendly, only: [:show]
-  before_action :set_group,
-                :check_if_user_can_access_group,
-                only: %i[index new create]
+  before_action :set_group, only: %i[index create]
 
   # GET /urls
   # GET /urls.json
@@ -172,9 +170,7 @@ class UrlsController < ApplicationController
     # otherwise use current_user's context_group_id
     group_id = params[:collection].presence || params.dig(:url, :group_id) || current_user.context_group_id
     @group = Group.find(group_id)
-  end
 
-  def check_if_user_can_access_group
     authorize @group, :update?
   rescue Pundit::NotAuthorizedError
     redirect_to urls_path, alert: "You do not have permission to access this collection. Redirected to your Z-Links."

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -19,8 +19,6 @@ class GroupPolicy < ApplicationPolicy
     user_has_access?
   end
 
-  private
-
   def user_has_access?
     return true if user.admin?
     return true if record.is_a?(Group) && record.users.exists?(user.id)

--- a/app/views/urls/_sleek_form.html.erb
+++ b/app/views/urls/_sleek_form.html.erb
@@ -19,6 +19,7 @@
               <%= f.text_field :keyword, class: 'js-new-url-keyword tw-border-none without-focus-ring tw-w-full tw-bg-transparent tw-text-umn-neutral-900 tw-h-full tw-py-4 tw-pl-1', placeholder: t('views.urls.sleek_form.placeholders.keyword'), 'aria-label': 'keyword' %>
             </div>
           </div>
+          <%= f.hidden_field :group_id, value: @group.id %>
           <button type="submit" class="js-url-submit tw-block !tw-bg-umn-gold tw-py-4 tw-px-8 tw-rounded-b-md md:tw-rounded-r-md md:tw-rounded-bl-none hover:!tw-bg-umn-gold-light active:!tw-bg-umn-neutral-900 active:!tw-text-white focus:tw-ring focus:tw-ring-offset-2 tw-transition-colors">
             <%= is_edit ? t('views.urls.sleek_form.edit.submit') : t('views.urls.sleek_form.new.submit')  %>
           </button>

--- a/app/views/urls/_sleek_form.html.erb
+++ b/app/views/urls/_sleek_form.html.erb
@@ -19,7 +19,7 @@
               <%= f.text_field :keyword, class: 'js-new-url-keyword tw-border-none without-focus-ring tw-w-full tw-bg-transparent tw-text-umn-neutral-900 tw-h-full tw-py-4 tw-pl-1', placeholder: t('views.urls.sleek_form.placeholders.keyword'), 'aria-label': 'keyword' %>
             </div>
           </div>
-          <%= f.hidden_field :group_id, value: @group.id %>
+          <%= f.hidden_field :group_id, value: @group.id if @group %>
           <button type="submit" class="js-url-submit tw-block !tw-bg-umn-gold tw-py-4 tw-px-8 tw-rounded-b-md md:tw-rounded-r-md md:tw-rounded-bl-none hover:!tw-bg-umn-gold-light active:!tw-bg-umn-neutral-900 active:!tw-text-white focus:tw-ring focus:tw-ring-offset-2 tw-transition-colors">
             <%= is_edit ? t('views.urls.sleek_form.edit.submit') : t('views.urls.sleek_form.new.submit')  %>
           </button>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,8 +8,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # While tests run files are not watched, reloading is not necessary.
-  config.enable_reloading = false
+  config.enable_reloading = true
 
   # Eager loading loads your entire application. When running a single test locally,
   # this is usually not necessary, and can slow down your test suite. However, it's

--- a/cypress/e2e/createZlinkInCollection.cy.ts
+++ b/cypress/e2e/createZlinkInCollection.cy.ts
@@ -1,27 +1,31 @@
 import user1 from "../fixtures/users/user1.json";
+import user2 from "../fixtures/users/user2.json";
 import { RailsModel } from "../types";
 
 describe("create zlink in collection", () => {
-  let myGroup: RailsModel.Group | null = null;
-  let notMyGroup: RailsModel.Group | null = null;
+  let user1Collection: RailsModel.Group | null = null;
+  let user2Collection: RailsModel.Group | null = null;
 
   beforeEach(() => {
     cy.app("clean");
-    cy.createAndLoginUser(user1.umndid);
-    cy.createGroup("testcollection")
+    cy.createUser(user1.umndid, { internet_id_loaded: user1.internet_id });
+    cy.createUser(user2.umndid, { internet_id_loaded: user2.internet_id });
+
+    cy.login(user1.umndid);
+
+    cy.createGroup("user1collection")
       .then((grp) => {
-        myGroup = grp;
+        user1Collection = grp;
         cy.addUserToGroup(user1.umndid, grp);
       })
-      .then(() => {
-        cy.createGroup("othercollection");
-      })
+      .then(() => cy.createGroup("user2collection"))
       .then((grp) => {
-        notMyGroup = grp;
+        user2Collection = grp;
+        cy.addUserToGroup(user2.umndid, grp);
       });
   });
   it("creates a zlink within the collection when on a collection page", () => {
-    cy.visit(`/shortener/urls?collection=${myGroup.id}`);
+    cy.visit(`/shortener/urls?collection=${user1Collection.id}`);
 
     // create a zlink on this collection page
     cy.get("#url_url").type("https://example.com");
@@ -34,18 +38,17 @@ describe("create zlink in collection", () => {
   });
 
   it("does not permit creating a zlink in a collection you do not have access to", () => {
-    cy.visit(`/shortener/urls?collection=${notMyGroup.id}`);
-    cy.get("#url_url").type("https://thisshouldntwork.com");
+    cy.visit(`/shortener/urls?collection=${user2Collection.id}`);
+    cy.get("#url_url").type("https://madeByUser1.com");
     cy.contains("Z-Link It").click();
 
-    // verify that the url was not created in the database
-    cy.appEval(`Url.where(url: "https://thisshouldntwork.com").count`).should(
-      "eq",
-      0
-    );
+    // expect to see the url in User 1's default collection
+    cy.visit("/shortener/urls");
+    cy.contains("https://madeByUser1.com").should("exist");
 
-    // cy.contains(
-    //   "You do not have permission to access this collection"
-    // ).should("exist");
+    // then check the user 2 collection to verify the url is not there
+    cy.login(user2.umndid);
+    cy.visit(`/shortener/urls?collection=${user2Collection.id}`);
+    cy.contains("https://madeByUser1.com").should("not.exist");
   });
 });

--- a/cypress/e2e/createZlinkInCollection.cy.ts
+++ b/cypress/e2e/createZlinkInCollection.cy.ts
@@ -1,0 +1,27 @@
+import user1 from "../fixtures/users/user1.json";
+import { RailsModel } from "../types";
+
+describe("create zlink in collection", () => {
+  let group: RailsModel.Group | null = null;
+
+  beforeEach(() => {
+    cy.app("clean");
+    cy.createAndLoginUser(user1.umndid);
+    cy.createGroup("testcollection").then((grp) => {
+      group = grp;
+      cy.addUserToGroup(user1.umndid, grp);
+    });
+  });
+  it("creates a zlink within the collection when on a collection page", () => {
+    cy.visit(`/shortener/urls?collection=${group.id}`);
+
+    // create a zlink on this collection page
+    cy.get("#url_url").type("https://example.com");
+    cy.contains("Z-Link It").click();
+
+    // expect to see the zlink within the collection
+    cy.get("#urls-table tbody tr:first-child").within(() => {
+      cy.contains("https://example.com").should("exist");
+    });
+  });
+});

--- a/cypress/e2e/createZlinkInCollection.cy.ts
+++ b/cypress/e2e/createZlinkInCollection.cy.ts
@@ -2,18 +2,26 @@ import user1 from "../fixtures/users/user1.json";
 import { RailsModel } from "../types";
 
 describe("create zlink in collection", () => {
-  let group: RailsModel.Group | null = null;
+  let myGroup: RailsModel.Group | null = null;
+  let notMyGroup: RailsModel.Group | null = null;
 
   beforeEach(() => {
     cy.app("clean");
     cy.createAndLoginUser(user1.umndid);
-    cy.createGroup("testcollection").then((grp) => {
-      group = grp;
-      cy.addUserToGroup(user1.umndid, grp);
-    });
+    cy.createGroup("testcollection")
+      .then((grp) => {
+        myGroup = grp;
+        cy.addUserToGroup(user1.umndid, grp);
+      })
+      .then(() => {
+        cy.createGroup("othercollection");
+      })
+      .then((grp) => {
+        notMyGroup = grp;
+      });
   });
   it("creates a zlink within the collection when on a collection page", () => {
-    cy.visit(`/shortener/urls?collection=${group.id}`);
+    cy.visit(`/shortener/urls?collection=${myGroup.id}`);
 
     // create a zlink on this collection page
     cy.get("#url_url").type("https://example.com");
@@ -23,5 +31,21 @@ describe("create zlink in collection", () => {
     cy.get("#urls-table tbody tr:first-child").within(() => {
       cy.contains("https://example.com").should("exist");
     });
+  });
+
+  it("does not permit creating a zlink in a collection you do not have access to", () => {
+    cy.visit(`/shortener/urls?collection=${notMyGroup.id}`);
+    cy.get("#url_url").type("https://thisshouldntwork.com");
+    cy.contains("Z-Link It").click();
+
+    // verify that the url was not created in the database
+    cy.appEval(`Url.where(url: "https://thisshouldntwork.com").count`).should(
+      "eq",
+      0
+    );
+
+    // cy.contains(
+    //   "You do not have permission to access this collection"
+    // ).should("exist");
   });
 });

--- a/cypress/e2e/urlsPageListZlinks.cy.ts
+++ b/cypress/e2e/urlsPageListZlinks.cy.ts
@@ -101,13 +101,17 @@ describe("urlsPageListZlinks - /shortener/urls", () => {
       // Sometimes cypress doesn't complete typing the full string
       // into the input field. Using `force: true` and manually triggering
       // `input` event to work around this issue.
-      cy.get("#group_name").type("testcollection", { force: true }).trigger('input');
+      cy.get("#group_name")
+        .type("testcollection", { force: true })
+        .trigger("input");
 
-      cy.get("#group_description").type("test description", { force: true }).trigger('input');
+      cy.get("#group_description")
+        .type("test description", { force: true })
+        .trigger("input");
 
       // submit
-      cy.contains('Submit').click();
-      cy.contains('Confirm').click();
+      cy.contains("Submit").click();
+      cy.contains("Confirm").click();
 
       // verify that the url was added to the collection
       cy.get("@claRow")
@@ -146,6 +150,22 @@ describe("urlsPageListZlinks - /shortener/urls", () => {
         "eq",
         "testcollection"
       );
+    });
+
+    it("redirects to the user's main urls page if params include a collection that the user does not own", () => {
+      cy.createGroup("testcollection").then((group) => {
+        cy.visit(`/shortener/urls?collection=${group.id}`, {
+          failOnStatusCode: false,
+        });
+
+        // should be redirected to the main urls page without
+        // the collection param
+        cy.location("pathname").should("eq", "/shortener/urls");
+        cy.location("search").should("eq", "");
+
+        // expect a flash message
+        cy.contains("You do not have permission to access this collection");
+      });
     });
 
     describe("filter and search the list of z-links", () => {


### PR DESCRIPTION
Resolves #11 

Before, on a collection page, if a user creates a new url, the url is not added to the collection as expected, but rather added to the user's default group. This changes the z-link creation form to include a (hidden) `group_id` parameter with collection info.

on dev for testing


https://github.com/UMN-LATIS/z/assets/980170/57392ec8-8bf3-4aeb-8a7d-b6ffd65e9631

