### PR TITLE
fix: passenger error page on deploy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -616,4 +616,4 @@ DEPENDENCIES
   web-console (~> 3.7)
 
 BUNDLED WITH
-   2.4.3
+   2.5.23


### PR DESCRIPTION
After deploying, passenger shows error page, because bundler versions don't match. The server version drifted from the version in the project. This updates to match the current server version `2.5.23`

See:
https://stackoverflow.com/questions/78911363/phusion-passenger-rails-server-error-no-such-file-or-directory-passenger-app

on dev for testing