### PR TITLE
update rails dev container for `mise`

### DIFF
--- a/.devcontainer/.bashrc
+++ b/.devcontainer/.bashrc
@@ -155,7 +155,9 @@ if [[ "$TERM" == "xterm" ]]; then
     # Append to PROMPT_COMMAND to call precmd before displaying the prompt
     PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }precmd"
 fi
-eval "$(rbenv init -)"
+
+# rails devcontainer's default changed to mise from rbenv
+eval "$(mise activate bash)"
 export PROMPT_COMMAND='history -a'
 export HISTFILE="${HOME}/.bash_history"
 


### PR DESCRIPTION
This updates bashrc in the devcontainer to initialize mise instead of rbenv.

The rails dev container changed their default ruby manager from `rbenv` to `mise` in https://github.com/rails/devcontainer/pull/86, breaking our bootstrap script.

