### PR TITLE
add aria attributes for qr-code dropdown menu

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -279,7 +279,8 @@ though the color below doesn't improve much.
     -moz-border-radius: 0 6px 6px 6px;
     border-radius: 0 6px 6px 6px;
   }
-  .dropdown-submenu:hover > .dropdown-menu {
+  .dropdown-submenu:hover > .dropdown-menu,
+  .dropdown-submenu:focus-within > .dropdown-menu  {
     display: block;
   }
   .dropdown-submenu > a:after {

--- a/app/assets/stylesheets/urls.scss
+++ b/app/assets/stylesheets/urls.scss
@@ -406,7 +406,6 @@ table.dataTable tr.selected .fa-ellipsis-h {
     background: none;
     border: none;
     padding: 3px;
-    outline: none;
     margin-top: -6px;
   }
   .delete-url,

--- a/app/views/urls/_in_row_actions.html.erb
+++ b/app/views/urls/_in_row_actions.html.erb
@@ -1,18 +1,19 @@
 <div class="actions-column">
   <div class="dropdown">
-    <button data-toggle="dropdown" class="actions-dropdown-button" aria-label="More Actions">
+    <button data-toggle="dropdown" class="actions-dropdown-button" aria-haspopup="true" aria-expanded="false" aria-controls="url-actions-menu-<%= url.id %>">
       <i class="fa fa-ellipsis-h">
       </i>
+      <span class="sr-only">More Actions</span>
     </button>
-    <ul class="dropdown-menu dropdown-menu-right">
+    <ul class="dropdown-menu dropdown-menu-right" id="url-actions-menu-<%= url.id %>" role="menu" aria-labelledby="url-actions-menu-<%= url.id %>">
       <li class="dropdown-submenu pull-left">
-        <%= link_to t('views.urls.index.table.in_row_actions.share'),
-                  '',
-                  class: 'btn action-button share-url fa fa-share-square-o',
-                  'data-content': render('urls/share_buttons', url: url) %>
+        <a href="#" class="btn action-button share-url" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="share-url-menu-<%= url.id %>">
+          <i class="fa fa-share-square-o !tw-text-black"></i>
+          <%= t('views.urls.index.table.in_row_actions.share') %>
+          </a>
         <ul class="dropdown-menu dropdown-menu-left">
           <li>
-            <button class="url-share-button js-share-button-twitter tw-text-twitter-blue !tw-text-sm" data-short-url="<%= full_url(url) %>">
+            <button class="url-share-button js-share-button-twitter tw-text-twitter-blue !tw-text-sm" data-short-url="<%= full_url(url) %>" role="menuitem">
               <i class="fa fa-twitter"></i>
               <%= t("views.urls.index.table.in_row_actions.twitter") %>
             </button>
@@ -20,19 +21,19 @@
         </ul>
       </li>
       <li class="dropdown-submenu pull-left">
-        <a href="#" class="btn action-button">
+        <a href="#" class="btn action-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="qr-code-download-menu-<%= url.id %>">
           <i class="fa fa-qrcode !tw-text-black"></i>
           <%= t('views.urls.index.table.in_row_actions.qr_code') %>
         </a>
-        <ul class="dropdown-menu dropdown-menu-left">
+        <ul class="dropdown-menu dropdown-menu-left" id="qr-code-download-menu-<%= url.id %>" role="menu" aria-labelledby="qr-code-download-menu-trigger-button">
           <li>
-            <a class="tw-text-left !tw-flex tw-justify-between tw-items-baseline" href="<%= url_download_qrcode_path(url.keyword) %>" download>
+            <a class="tw-text-left !tw-flex tw-justify-between tw-items-baseline" href="<%= url_download_qrcode_path(url.keyword) %>" download role="menuitem">
               PNG
               <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400">Standard</span>
             </a>
           </li>
           <li>
-            <a class="tw-text-left !tw-flex tw-justify-between tw-items-baseline" href="<%= url_download_qrcode_path(url.keyword, format: :svg) %>" download>
+            <a class="tw-text-left !tw-flex tw-justify-between tw-items-baseline" href="<%= url_download_qrcode_path(url.keyword, format: :svg) %>" download role="menuitem">
               SVG
               <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400">Advanced</span>
             </a>

--- a/app/views/urls/_in_row_actions.html.erb
+++ b/app/views/urls/_in_row_actions.html.erb
@@ -1,13 +1,13 @@
 <div class="actions-column">
   <div class="dropdown">
-    <button data-toggle="dropdown" class="actions-dropdown-button" aria-haspopup="true" aria-expanded="false" aria-controls="url-actions-menu-<%= url.id %>">
+    <button data-toggle="dropdown" class="actions-dropdown-button" aria-haspopup="true" aria-controls="url-actions-menu-<%= url.id %>">
       <i class="fa fa-ellipsis-h">
       </i>
       <span class="sr-only">More Actions</span>
     </button>
     <ul class="dropdown-menu dropdown-menu-right" id="url-actions-menu-<%= url.id %>" role="menu" aria-labelledby="url-actions-menu-<%= url.id %>">
       <li class="dropdown-submenu pull-left">
-        <a href="#" class="btn action-button share-url" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="share-url-menu-<%= url.id %>">
+        <a href="#" class="btn action-button share-url" data-toggle="dropdown" aria-haspopup="true" aria-controls="share-url-menu-<%= url.id %>">
           <i class="fa fa-share-square-o !tw-text-black"></i>
           <%= t('views.urls.index.table.in_row_actions.share') %>
           </a>
@@ -21,7 +21,7 @@
         </ul>
       </li>
       <li class="dropdown-submenu pull-left">
-        <a href="#" class="btn action-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="qr-code-download-menu-<%= url.id %>">
+        <a href="#" class="btn action-button" data-toggle="dropdown" aria-haspopup="true" aria-controls="qr-code-download-menu-<%= url.id %>">
           <i class="fa fa-qrcode !tw-text-black"></i>
           <%= t('views.urls.index.table.in_row_actions.qr_code') %>
         </a>
@@ -43,33 +43,42 @@
       <li>
         <%= link_to t('views.urls.index.table.in_row_actions.stats'),
                     url_path(url.keyword),
-                    class: 'btn action-button show-url fa fa-bar-chart' %>
+                    class: 'btn action-button show-url fa fa-bar-chart',
+                     role: 'menuitem'
+                     %>
       </li>
       <% if admin_view %>
         <li>
           <%= link_to t('views.urls.index.table.in_row_actions.edit'),
                       edit_admin_url_path(url),
-                      class: 'btn action-button edit-url fa fa-pencil', remote: true %>
+                      class: 'btn action-button edit-url fa fa-pencil', remote: true,
+                       role: 'menuitem'
+                       %>
         </li>
         <li>
           <%= link_to t('views.urls.index.table.in_row_actions.delete'),
                       admin_url_path(url),
                       method: :delete,
                       data: { confirm: t('views.urls.index.table.in_row_actions.delete_confirm', keyword: url.keyword) },
-                      class: 'btn action-button delete-url fa fa-trash-o', remote: true %>
+                      class: 'btn action-button delete-url fa fa-trash-o', remote: true,
+                      role: 'menuitem' %>
         </li>
       <% else %>
         <li>
           <%= link_to t('views.urls.index.table.in_row_actions.edit'),
                       edit_url_path(url),
-                      class: 'btn action-button edit-url fa fa-pencil', remote: true %>
+                      class: 'btn action-button edit-url fa fa-pencil', remote: true,
+                       role: 'menuitem'
+                       %>
         </li>
         <li>
           <%= link_to t('views.urls.index.table.in_row_actions.delete'),
                       url_path(url),
                       method: :delete,
                       data: { confirm: t('views.urls.index.table.in_row_actions.delete_confirm', keyword: url.keyword) },
-                      class: 'btn delete-url fa fa-trash-o', remote: true %>
+                      class: 'btn delete-url fa fa-trash-o', remote: true,
+                      role: 'menuitem'
+                       %>
         </li>
       <% end %>
     </ul>

--- a/app/views/urls/_share_buttons.html.erb
+++ b/app/views/urls/_share_buttons.html.erb
@@ -7,8 +7,8 @@
 </button>
 <!-- QR Code split download button -->
 <div class="btn-group">
-  <a href="<%= url_download_qrcode_path(url.keyword) %>" class="btn btn-default <%= is_large %> " download>
-    <i class="fa fa-qrcode"></i>
+  <a href="<%= url_download_qrcode_path(url.keyword) %>" class="btn btn-default <%= is_large %> " download aria-label="Download QR Code">
+    <i class="fa fa-qrcode" aria-hidden="true"></i>
     <%= t('views.urls.index.table.in_row_actions.qr_code') %>
   </a>
   <button id="qr-code-download-menu-trigger-button" type="button" class="btn btn-default dropdown-toggle  <%= is_large %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="qr-code-download-menu">
@@ -17,16 +17,15 @@
   </button>
   <ul class="dropdown-menu" id="qr-code-download-menu" role="menu" aria-labelledby="qr-code-download-menu-trigger-button">
     <li>
-      <a href="<%= url_download_qrcode_path(url.keyword) %>" download class="!tw-flex tw-justify-between tw-items-baseline">
-        <span class="sr-only">Download</span> PNG 
-        <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400">Standard</span>
+      <a role="menuitem" href="<%= url_download_qrcode_path(url.keyword) %>" download class="!tw-flex tw-justify-between tw-items-baseline">
+        <span aria-label="Download PNG">PNG</span>
+        <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400" aria-label="(Standard option)">Standard</span>
       </a>
     </li>
     <li>
-      <a href="<%= url_download_qrcode_path(url.keyword, format: :svg) %>" download class="!tw-flex tw-justify-between tw-items-baseline">
-        <span class="sr-only">Download</span>
-        SVG 
-        <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400">Advanced</span>
+      <a role="menuitem" href="<%= url_download_qrcode_path(url.keyword, format: :svg) %>" download class="!tw-flex tw-justify-between tw-items-baseline">
+        <span aria-label="Download SVG">SVG</span>
+        <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400" aria-label="(Advanced option)">Advanced</span>
       </a>
     </li>
   </ul>

--- a/app/views/urls/_share_buttons.html.erb
+++ b/app/views/urls/_share_buttons.html.erb
@@ -11,19 +11,20 @@
     <i class="fa fa-qrcode"></i>
     <%= t('views.urls.index.table.in_row_actions.qr_code') %>
   </a>
-  <button type="button" class="btn btn-default dropdown-toggle  <%= is_large %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="qr-code-download-menu-trigger-button" type="button" class="btn btn-default dropdown-toggle  <%= is_large %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="qr-code-download-menu">
     <span class="caret"></span>
-    <span class="sr-only">Toggle Dropdown</span>
+    <span class="sr-only">Download Options</span>
   </button>
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu" id="qr-code-download-menu" role="menu" aria-labelledby="qr-code-download-menu-trigger-button">
     <li>
       <a href="<%= url_download_qrcode_path(url.keyword) %>" download class="!tw-flex tw-justify-between tw-items-baseline">
-        PNG 
+        <span class="sr-only">Download</span> PNG 
         <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400">Standard</span>
       </a>
     </li>
     <li>
       <a href="<%= url_download_qrcode_path(url.keyword, format: :svg) %>" download class="!tw-flex tw-justify-between tw-items-baseline">
+        <span class="sr-only">Download</span>
         SVG 
         <span class="tw-uppercase tw-text-[0.75em] tw-text-neutral-400">Advanced</span>
       </a>


### PR DESCRIPTION
Fix accessibility and user experience issues for dropdown menus and action buttons in the URL management views. 

* Added ARIA attributes (`aria-haspopup`, `aria-controls`, `aria-label`, `role="menu"`, `role="menuitem"`) to dropdown buttons and menu items in `_in_row_actions.html.erb` and `_share_buttons.html.erb` to improve screen reader and keyboard navigation support.
* Updated QR code download options to include clearer labels and ARIA attributes for better accessibility in `_share_buttons.html.erb`.
* Modified dropdown submenu CSS to support keyboard navigation by displaying menus on `:focus-within` in `layout.scss`.
* Improved structure of dropdown menus by ensuring each has a unique `id` and is properly linked to its trigger button with ARIA attributes.
* Removed  `outline: none;` from the `.actions-dropdown-button` so that button focus outline displays
* Added screen reader-only text where context was missing.

closes #200 
closes #228 

Partially resolves #239 - My Collections page needs a similar fix.
Partially resolves #225 - Bulk Actions remaining