### PR TITLE
fix(a11y): replace bulk actions dropdown with buttons

### DIFF
--- a/app/assets/javascripts/urls.js
+++ b/app/assets/javascripts/urls.js
@@ -322,28 +322,25 @@ function initializeUrlDataTable(sortColumn, sortOrder, actionColumn, keywordColu
     });
     $bulkActionsContainer.append($transferButton);
 
-    // Move button (only show if multiple collections)
-    if (showMoveButton) {
-        const $moveButton = $(`
-            <button type="button"
-                    class="btn btn-default js-move-urls bulk-action-btn"
-                    aria-disabled="true"
-                    data-toggle="tooltip"
-                    title="${I18n.t("views.urls.move_button")}">
-                <span class="sr-only">${I18n.t("views.urls.move_button")}</span>
-                <i class="fa fa-share-square-o" aria-hidden="true"></i>
-            </button>
-        `);
-        $moveButton.on('click', (e) => {
-            if ($(e.currentTarget).attr('aria-disabled') === 'true') {
-                e.preventDefault();
-                return false;
-            }
-            const keywords = userTable.rows('.selected').data().map(row => row['DT_RowData_keyword']).toArray();
-            moveUrl($('.route-info').data('new-move-to-group-path'), keywords);
-        });
-        $bulkActionsContainer.append($moveButton);
-    }
+    const $moveButton = $(`
+        <button type="button"
+                class="btn btn-default js-move-urls bulk-action-btn"
+                aria-disabled="true"
+                data-toggle="tooltip"
+                title="${I18n.t("views.urls.move_button")}">
+            <span class="sr-only">${I18n.t("views.urls.move_button")}</span>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"><!-- Icon from Material Symbols by Google - https://github.com/google/material-design-icons/blob/master/LICENSE --><path fill="currentColor" d="M8 18q-.825 0-1.412-.587T6 16v-1q0-.425.288-.712T7 14t.713.288T8 15v1h12V6H8v1q0 .425-.288.713T7 8t-.712-.288T6 7V4q0-.825.588-1.412T8 2h12q.825 0 1.413.588T22 4v12q0 .825-.587 1.413T20 18zm-4 4q-.825 0-1.412-.587T2 20V7q0-.425.288-.712T3 6t.713.288T4 7v13h13q.425 0 .713.288T18 21t-.288.713T17 22zm9.175-10H7q-.425 0-.712-.288T6 11t.288-.712T7 10h6.175l-.9-.9Q12 8.825 12 8.413t.3-.713q.275-.275.7-.275t.7.275l2.6 2.6q.3.3.3.7t-.3.7l-2.6 2.6q-.275.275-.687.288T12.3 14.3q-.275-.275-.275-.7t.275-.7z"/></svg>
+        </button>
+    `);
+    $moveButton.on('click', (e) => {
+        if ($(e.currentTarget).attr('aria-disabled') === 'true') {
+            e.preventDefault();
+            return false;
+        }
+        const keywords = userTable.rows('.selected').data().map(row => row['DT_RowData_keyword']).toArray();
+        moveUrl($('.route-info').data('new-move-to-group-path'), keywords);
+    });
+    $bulkActionsContainer.append($moveButton);
 
     // Batch delete button (always shown)
     const $deleteButton = $(`

--- a/app/assets/javascripts/urls.js
+++ b/app/assets/javascripts/urls.js
@@ -141,11 +141,6 @@ function changeGroup(groupPath, keyword) {
 }
 
 function initializeUrlDataTable(sortColumn, sortOrder, actionColumn, keywordColumn, showMoveButton, collectionSelect) {
-    var transferText = '<i class="fa fa-exchange"></i> ' + I18n.t("views.urls.transfer_button");
-    var moveText = '<i class="fa fa-share-square-o "></i> ' + I18n.t("views.urls.move_button");
-    var batchDeleteText = '<i class="fa fa-trash-o "></i> ' + I18n.t("views.urls.batch_delete_button");
-    var bulkActionsText = I18n.t("views.urls.bulk_actions") + '<i class="fa fa-sort-desc "></i> ';
-
     var $urlsTable = $('#urls-table');
     var userTable = $urlsTable.DataTable({
         drawCallback: function(settings) {
@@ -282,19 +277,14 @@ function initializeUrlDataTable(sortColumn, sortOrder, actionColumn, keywordColu
         }
     });
 
-    //function for disabling bulk table options dropdown
+    //function for disabling bulk action buttons when no rows are selected
     function enableDisableTableOptions(){
-      var selectedRows = userTable.rows('.selected');
-      if (selectedRows[0].length){
-        $(".table-options").removeClass("disabled");
-      }
-      else{
-        $(".table-options").addClass("disabled");
-
-      }
+      const selectedRows = userTable.rows('.selected');
+      const isDisabled = selectedRows[0].length === 0;
+      $(".js-transfer-urls, .js-move-urls, .js-delete-urls").attr("aria-disabled", isDisabled.toString());
     }
 
-    //use the function for disabling bulk table options dropdown
+    //use the function for disabling bulk action buttons
     userTable.on('select', enableDisableTableOptions);
     userTable.on('deselect', enableDisableTableOptions);
 
@@ -308,73 +298,80 @@ function initializeUrlDataTable(sortColumn, sortOrder, actionColumn, keywordColu
         }).select() : userTable.rows().deselect();
     });
 
-    var transfer_button = {
-        extend: 'selected',
-        text: transferText,
-        className: 'btn js-transfer-urls',
-        action: function(e, dt, node, config) {
-            var keywords = [];
-            userTable.rows('.selected').data().map(function(row) {
-                keywords.push(row['DT_RowData_keyword'])
-            });
-            transferUrl($('.route-info').data('new-transfer-request-path'), keywords);
+    // Create bulk action buttons container
+    const $bulkActionsContainer = $('<div class="bulk-actions-buttons"></div>');
+
+    // Transfer button
+    const $transferButton = $(`
+        <button type="button"
+                class="btn btn-default js-transfer-urls bulk-action-btn"
+                aria-disabled="true"
+                data-toggle="tooltip"
+                title="${I18n.t("views.urls.transfer_button")}">
+            <span class="sr-only">${I18n.t("views.urls.transfer_button")}</span>
+            <i class="fa fa-exchange" aria-hidden="true"></i>
+        </button>
+    `);
+    $transferButton.on('click', (e) => {
+        if ($(e.currentTarget).attr('aria-disabled') === 'true') {
+            e.preventDefault();
+            return false;
         }
-    }
-
-    var move_button = {
-        extend: 'selected',
-        className: 'btn js-move-urls',
-        text: moveText,
-        action: function(e, dt, node, config) {
-            var keywords = [];
-            userTable.rows('.selected').data().map(function(row) {
-                keywords.push(row['DT_RowData_keyword'])
-            });
-
-            moveUrl($('.route-info').data('new-move-to-group-path'), keywords);
-        }
-    }
-
-    var batch_delete_button = {
-        extend: 'selected',
-        className: 'btn btn-danger js-delete-urls',
-        text: batchDeleteText,
-        action: function(e, dt, node, config) {
-            var keywords = [];
-            userTable.rows('.selected').data().map(function(row) {
-                keywords.push(row['DT_RowData_keyword'])
-            });
-
-            batchDelete($('.route-info').data('new-batch-delete-path'), keywords);
-        }
-    }
-
-    buttons = []
-    if (showMoveButton) {
-        buttons = [transfer_button, move_button, batch_delete_button]
-    } else {
-        buttons = [transfer_button]
-    }
-
-    var dropdown_button = {
-        extend: 'collection',
-        text: bulkActionsText,
-        className: 'table-options',
-        autoClose: true,
-        fade: 200,
-        buttons: buttons
-    }
-
-    new $.fn.dataTable.Buttons(userTable, {
-        buttons: [dropdown_button]
+        const keywords = userTable.rows('.selected').data().map(row => row['DT_RowData_keyword']).toArray();
+        transferUrl($('.route-info').data('new-transfer-request-path'), keywords);
     });
+    $bulkActionsContainer.append($transferButton);
 
-    userTable
-        .buttons(0, null)
-        .container()
-        .prependTo('.dataTables_wrapper >.row:eq(0) > .col-sm-6:eq(0)');
+    // Move button (only show if multiple collections)
+    if (showMoveButton) {
+        const $moveButton = $(`
+            <button type="button"
+                    class="btn btn-default js-move-urls bulk-action-btn"
+                    aria-disabled="true"
+                    data-toggle="tooltip"
+                    title="${I18n.t("views.urls.move_button")}">
+                <span class="sr-only">${I18n.t("views.urls.move_button")}</span>
+                <i class="fa fa-share-square-o" aria-hidden="true"></i>
+            </button>
+        `);
+        $moveButton.on('click', (e) => {
+            if ($(e.currentTarget).attr('aria-disabled') === 'true') {
+                e.preventDefault();
+                return false;
+            }
+            const keywords = userTable.rows('.selected').data().map(row => row['DT_RowData_keyword']).toArray();
+            moveUrl($('.route-info').data('new-move-to-group-path'), keywords);
+        });
+        $bulkActionsContainer.append($moveButton);
+    }
 
-    $(".col-sm-6 .dt-buttons").removeClass("btn-group");
+    // Batch delete button (always shown)
+    const $deleteButton = $(`
+        <button type="button"
+                class="btn btn-outline-danger js-delete-urls bulk-action-btn"
+                aria-disabled="true"
+                data-toggle="tooltip"
+                title="${I18n.t("views.urls.batch_delete_button")}">
+            <span class="sr-only">${I18n.t("views.urls.batch_delete_button")}</span>
+            <i class="fa fa-trash-o" aria-hidden="true"></i>
+        </button>
+    `);
+    $deleteButton.on('click', (e) => {
+        if ($(e.currentTarget).attr('aria-disabled') === 'true') {
+            e.preventDefault();
+            return false;
+        }
+        const keywords = userTable.rows('.selected').data().map(row => row['DT_RowData_keyword']).toArray();
+        batchDelete($('.route-info').data('new-batch-delete-path'), keywords);
+    });
+    $bulkActionsContainer.append($deleteButton);
+
+    // Add buttons to the DataTable wrapper
+    $bulkActionsContainer.prependTo('.dataTables_wrapper >.row:eq(0) > .col-sm-6:eq(0)');
+
+    // Initialize tooltips
+    $('.bulk-action-btn').tooltip();
+
     return userTable;
 }
 

--- a/app/assets/stylesheets/urls.scss
+++ b/app/assets/stylesheets/urls.scss
@@ -216,6 +216,28 @@ table.dataTable thead .sorting_desc_disabled:after {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  margin: 0;
+  flex-wrap: wrap;
+  gap: 1rem;
+
+  &:before,
+  &:after {
+    display: none;
+  }
+
+  @media (max-width: 640px) {
+    // bulk actions should always be closer to checkbox
+    // so reorder on small screens
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .col-sm-6 {
+    padding: 0;
+    margin: 0;
+    float: none;
+    width: auto;
+  }
 
   #urls-table_filter {
     padding: 0;

--- a/app/assets/stylesheets/urls.scss
+++ b/app/assets/stylesheets/urls.scss
@@ -208,9 +208,40 @@ table.dataTable thead .sorting_desc_disabled:after {
   }
 }
 
+// action buttons at top of urls datatable
+// below is futzing to bulk action buttons to align
+// with collection filter and search box
+// mostly overriding bootstrap
+#urls-table_wrapper .row:first-child {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+
+  #urls-table_filter {
+    padding: 0;
+    margin: 0;
+    display: flex;
+    align-items: baseline;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+
+    & label {
+      margin: 0;
+      margin-left: 0.5rem;
+
+    }
+    & input {
+      margin: 0;
+      margin-left: 0.25rem;
+      padding: 0.25rem 0.5rem;
+      font-size: 0.75rem;
+    }
+  }
+}
+
 .bulk-actions-buttons {
-  white-space: nowrap;
-  margin-bottom: 0.625rem;
+  display: flex;
+  align-items: center;
 
   .btn {
     min-width: 2.5rem;
@@ -233,7 +264,7 @@ table.dataTable thead .sorting_desc_disabled:after {
       background: none;
       color: #d95450;
       border: 1px solid #d95450;
-      &:hover {
+      &:hover:not([aria-disabled="true"]) {
         background-color: #d92232;
         color: white;
         border: 1px solid #d92232;
@@ -268,18 +299,6 @@ table.dataTable thead .sorting_desc_disabled:after {
   .btn-xs {
     padding: 3px 7px;
     display: inline;
-    vertical-align: middle;
-  }
-}
-
-#collection-filter {
-  margin: 0 15px 0 5px;
-}
-
-#urls-table_filter {
-  margin-top: 8px;
-  label {
-    display: inline-block;
     vertical-align: middle;
   }
 }

--- a/app/assets/stylesheets/urls.scss
+++ b/app/assets/stylesheets/urls.scss
@@ -169,38 +169,6 @@ table.dataTable {
     width: 300px !important;
   }
 }
-.table-options {
-  &.disabled {
-    cursor: not-allowed;
-  }
-  i {
-    margin-left: 5px !important;
-    vertical-align: top;
-  }
-}
-.dt-button-collection.dropdown-menu {
-  padding: 0;
-  overflow: hidden;
-  li.btn {
-    padding: 0;
-    display: block;
-    text-align: left;
-    a {
-      padding: 14px 32px;
-    }
-    &.btn-danger {
-      border-radius: 0;
-      border: none;
-      color: white;
-      a {
-        color: white;
-        &:hover {
-          background-color: transparent;
-        }
-      }
-    }
-  }
-}
 @media screen and (max-width: 900px) {
   .table-row-edit-main {
     .super-input {
@@ -240,14 +208,37 @@ table.dataTable thead .sorting_desc_disabled:after {
   }
 }
 
-.dt-buttons {
+.bulk-actions-buttons {
   white-space: nowrap;
+  margin-bottom: 0.625rem;
 
   .btn {
-    margin: 3px;
-  }
-  :first-child {
-    margin-left: 0px;
+    min-width: 2.5rem;
+    padding: 0.375rem 0.75rem;
+    margin-right: 0.5rem;
+
+    &:last-child {
+      margin-right: 0;
+    }
+
+    &[aria-disabled="true"] {
+      cursor: not-allowed;
+      opacity: 0.4;
+    }
+
+    i {
+      margin: 0;
+    }
+    &.btn-outline-danger {
+      background: none;
+      color: #d95450;
+      border: 1px solid #d95450;
+      &:hover {
+        background-color: #d92232;
+        color: white;
+        border: 1px solid #d92232;
+      }
+    }
   }
 }
 

--- a/cypress/e2e/movingUrlsToAGroup.cy.ts
+++ b/cypress/e2e/movingUrlsToAGroup.cy.ts
@@ -44,7 +44,6 @@ describe("moving urls to a group", () => {
     cy.get("@duluthRow").find("td.select-checkbox").click();
 
     // click bulk actions button
-    cy.contains("Bulk Actions").click();
     cy.contains("Move to a different collection").click();
 
     // open the dropdown of collections


### PR DESCRIPTION
This resolves an accessibility issue with the bulk actions button where the select was not keyboard accessible until an item was selected, and the select dropdown itself was not accessible.

So:
- Changed the bulk actions jquery "select" plugin to buttons. We chose buttons over a native select since iconography seemed important.
- Changed from `disabled` attr to `aria-disabled` which will keep the actions discoverable via keyboard and permits tooltips to show.
- Updated CSS to resolve alignment (mostly overriding datatable's bootstrap).

On dev for testing:

https://github.com/user-attachments/assets/58c0ccff-e8a9-406b-8061-4085eb47eecb

