### PR TITLE
fix(a11y): my zlinks - checkboxes not keyboard accessible

### DIFF
--- a/app/assets/javascripts/urls.js
+++ b/app/assets/javascripts/urls.js
@@ -150,11 +150,11 @@ function initializeUrlDataTable(sortColumn, sortOrder, actionColumn, keywordColu
         "pageLength": 25,
         "autoWidth": false,
         columns: [{
-            defaultContent: "<input type='checkbox' class='select-checkbox' aria-label='select/deselect current row'/>",
+            defaultContent: "<input type='checkbox' class='select-checkbox' aria-label='Select row'/>",
             className: 'select-checkbox__container',
             searchable: false,
             orderable: false,
-            title: "<input type='checkbox' id='select-all' class='select-checkbox' aria-label='select/deselect all rows'/>"
+            title: "<input type='checkbox' id='select-all' class='select-checkbox' aria-label='Select all rows'/>"
         }, {
             data: 'group_id',
             visible: false,

--- a/app/assets/javascripts/urls.js
+++ b/app/assets/javascripts/urls.js
@@ -150,8 +150,8 @@ function initializeUrlDataTable(sortColumn, sortOrder, actionColumn, keywordColu
         "pageLength": 25,
         "autoWidth": false,
         columns: [{
-            defaultContent: "",
-            className: 'select-checkbox',
+            defaultContent: "<input type='checkbox' class='select-checkbox' aria-label='select/deselect current row'/>",
+            className: 'select-checkbox__container',
             searchable: false,
             orderable: false,
             title: "<input type='checkbox' id='select-all' class='select-checkbox' aria-label='select/deselect all rows'/>"

--- a/cypress/e2e/movingUrlsToAGroup.cy.ts
+++ b/cypress/e2e/movingUrlsToAGroup.cy.ts
@@ -40,8 +40,8 @@ describe("moving urls to a group", () => {
     cy.get("#urls-table").contains("duluth").closest("tr").as("duluthRow");
 
     // select morris and duluth rows
-    cy.get("@morrisRow").find("td.select-checkbox").click();
-    cy.get("@duluthRow").find("td.select-checkbox").click();
+    cy.get("@morrisRow").find("td .select-checkbox").click();
+    cy.get("@duluthRow").find("td .select-checkbox").click();
 
     // click bulk actions button
     cy.contains("Move to a different collection").click();


### PR DESCRIPTION
Add  `<input type="checkbox">` for each row to the checkbox column to make it keyboard accessible.

Fixes #238