### PR TITLE
fix(a11y): faq accordions expand state

### DIFF
--- a/app/assets/stylesheets/faq.scss
+++ b/app/assets/stylesheets/faq.scss
@@ -2,16 +2,3 @@
   font-size: 25px;
   margin: 10px;
 }
-
-.panel-heading [data-toggle="collapse"]:after {
-  font-family: 'FontAwesome';
-  content: "\f077"; /* fa-chevron-up */
-  float: right;
-  color: #000000;
-  font-size: 18px;
-  line-height: 22px;
-}
-
-.panel-heading [data-toggle="collapse"].collapsed:after {
-  content: "\f078";  /* fa-chevron-down */
-}

--- a/app/views/faq/index.html.erb
+++ b/app/views/faq/index.html.erb
@@ -5,20 +5,14 @@
   <div class="umn-post-it">
     <div class="panel-group" id="accordion">
       <% @faqs.each_with_index do |faq, index| %>
-        <div class="panel panel-default">
-          <div class="panel-heading tw-p-4">
-            <h4 class="panel-title">
-              <a id="q<%= index %>" class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapse<%= index %>">
-                <%= faq.question.html_safe %>
-              </a>
-            </h4>
+        <details class="tw-mb-4 tw-border tw-border-neutral-300 tw-rounded-lg tw-overflow-clip tw-group">
+          <summary class="tw-cursor-pointer group-open:tw-font-bold tw-bg-neutral-100 tw-p-4">
+              <%= faq.question.html_safe %>
+          </summary>
+          <div class="tw-mt-2 tw-ml-4 tw-p-4">
+            <%= faq.answer.html_safe %>
           </div>
-          <div id="collapse<%= index %>" class="panel-collapse collapse">
-            <div class="panel-body">
-              <%= faq.answer.html_safe %>
-            </div>
-          </div>
-        </div>
+        </details>
       <% end %>
     </div>
   </div>

--- a/app/views/faq/index.html.erb
+++ b/app/views/faq/index.html.erb
@@ -6,7 +6,7 @@
     <div class="panel-group" id="accordion">
       <% @faqs.each_with_index do |faq, index| %>
         <details class="tw-mb-4 tw-border tw-border-neutral-300 tw-rounded-lg tw-overflow-clip tw-group">
-          <summary class="tw-cursor-pointer group-open:tw-font-bold tw-bg-neutral-100 tw-p-4">
+          <summary class="tw-cursor-pointer group-open:tw-font-bold tw-bg-neutral-100 tw-p-4" data-cy="faq-question">
               <%= faq.question.html_safe %>
           </summary>
           <div class="tw-mt-2 tw-ml-4 tw-p-4">

--- a/cypress/e2e/faqPage.cy.ts
+++ b/cypress/e2e/faqPage.cy.ts
@@ -35,10 +35,14 @@ describe("FAQ Page", () => {
       .should("contain", "What is Z?")
       .should("contain", "Should I use it?");
 
+    // default with no answers visible
+    cy.get('details').should('not.have.attr', 'open')
+
     // click on the first question
     cy.contains("What is Z?").click();
 
     // answer should be visible
+    cy.get('details').first().should('have.attr', 'open')
     cy.contains("This site is used to shorten URLs.").should("be.visible");
   });
 });

--- a/cypress/e2e/faqPage.cy.ts
+++ b/cypress/e2e/faqPage.cy.ts
@@ -30,13 +30,10 @@ describe("FAQ Page", () => {
     cy.get("h1").should("contain", "Frequently Asked Questions");
 
     // two questions
-    cy.get(".panel-heading")
+    cy.get("[data-cy=faq-question]")
       .should("have.length", 2)
       .should("contain", "What is Z?")
       .should("contain", "Should I use it?");
-
-    // answers should be collapsed
-    cy.get(".panel-body").should("have.length", 2).should("not.be.visible");
 
     // click on the first question
     cy.contains("What is Z?").click();


### PR DESCRIPTION
This resolves an accessibility issue where the faq panels don't communicate whether the panel is open or not. We swap custom accordion code for native HTML elements `<details>` and `<summary>`. 

https://github.com/user-attachments/assets/ed8a10f5-ab0b-4f9b-a94f-3bbe76222318

