### PR TITLE
Adds table header to URL statistics display

### DIFF
--- a/app/views/urls/show.html.erb
+++ b/app/views/urls/show.html.erb
@@ -122,6 +122,13 @@
                 <%= t('views.urls.show.created_on')%> <%= @url.created_at.to_fs(:created_on_formatted) %> (<%= time_ago_in_words(@url.created_at) %> ago)
               </div>
               <table class="table table-hover">
+                <thead>
+                  <tr>
+                    <th scope="col">Time Period</th>
+                    <th scope="col">Total Hits</th>
+                    <th scope="col">Average</th>
+                  </tr>
+                </thead>
                 <tbody>
                   <tr>
                     <td><%= t('views.urls.show.hours_24')%></td>


### PR DESCRIPTION
Fixes [a11y] Z-link stats - Historical click count table missing headers 

Fixes #235