### PR TITLE
fix(a11y): add aria-current to active pagination link

### DIFF
--- a/app/assets/javascripts/group_members.js
+++ b/app/assets/javascripts/group_members.js
@@ -7,7 +7,13 @@ $(document).bind('turbolinks:load', function () {
      "columnDefs": [ {
       "targets": 2,
       "orderable": false
-      } ]
+      } ],
+     drawCallback: function(settings) {
+       // Add aria-current to active pagination link for accessibility
+       var pagination = $(this).closest('.dataTables_wrapper').find('.dataTables_paginate');
+       pagination.find('.paginate_button').removeAttr('aria-current');
+       pagination.find('.paginate_button.current').attr('aria-current', 'page');
+     }
    });
 });
 

--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -9,6 +9,12 @@ $(document).bind('turbolinks:load', function () {
      "columnDefs": [ {
       "targets": 4,
       "orderable": false
-      } ]
+      } ],
+     drawCallback: function(settings) {
+       // Add aria-current to active pagination link for accessibility
+       var pagination = $(this).closest('.dataTables_wrapper').find('.dataTables_paginate');
+       pagination.find('.paginate_button').removeAttr('aria-current');
+       pagination.find('.paginate_button.current').attr('aria-current', 'page');
+     }
    });
 });

--- a/app/assets/javascripts/urls.js
+++ b/app/assets/javascripts/urls.js
@@ -146,6 +146,10 @@ function initializeUrlDataTable(sortColumn, sortOrder, actionColumn, keywordColu
         drawCallback: function(settings) {
             var pagination = $(this).closest('.dataTables_wrapper').find('.dataTables_paginate');
             pagination.toggle(this.api().page.info().pages > 1);
+
+            // Add aria-current to active pagination link for accessibility
+            pagination.find('.paginate_button').removeAttr('aria-current');
+            pagination.find('.paginate_button.current').attr('aria-current', 'page');
         },
         "pageLength": 25,
         "autoWidth": false,


### PR DESCRIPTION
`aria-current` is an ARIA attribute that tells screen readers which item in a set is the current/active one. Values are like "page", "step", "location", etc.  Akin to `aria-selected`.

Without aria-current, screen reader users navigating pagination just hear "1, 2, 3, 4..." with no indication of which page
   they're on.

With aria-current="page", they hear something like "3, current page" so they know where they are.

In this fix, for each draw of datatables, we reset the `aria-current`.

fixes #231