### PR TITLE
fix(a11y): announce errors to screenreaders

### DIFF
--- a/app/views/admin/announcements/_form.html.erb
+++ b/app/views/admin/announcements/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for(admin_announcement) do |f| %>
     <% if admin_announcement.errors.any? %>
-        <div id="error_explanation">
+        <div id="error_explanation" role="alert" aria-live="assertive" aria-atomic="true">
           <h2><%= pluralize(admin_announcement.errors.count, "error") %> prohibited this admin_announcement from being
             saved:</h2>
 

--- a/app/views/admin/groups/_in_row_errors.html.erb
+++ b/app/views/admin/groups/_in_row_errors.html.erb
@@ -1,1 +1,1 @@
-<div class="error-space"><%= group.errors.full_messages.join('. ') %></div>
+<div class="error-space" role="alert" aria-live="assertive" aria-atomic="true"><%= group.errors.full_messages.join('. ') %></div>

--- a/app/views/groups/_in_row_errors.html.erb
+++ b/app/views/groups/_in_row_errors.html.erb
@@ -1,1 +1,1 @@
-<div class="error-space"><%= group.errors.full_messages.join('. ') %></div>
+<div class="error-space" role="alert" aria-live="assertive" aria-atomic="true"><%= group.errors.full_messages.join('. ') %></div>

--- a/app/views/groups/_new_modal.html.erb
+++ b/app/views/groups/_new_modal.html.erb
@@ -7,7 +7,7 @@
     <%= form_for_group_admin @admin_view, @group do |f| %>
 
       <div class="modal-body">
-          <div class="error-space"><%= @group.errors.full_messages.join('. ') %></div>
+          <div class="error-space" role="alert" aria-live="assertive" aria-atomic="true"><%= @group.errors.full_messages.join('. ') %></div>
 
             <%= hidden_field_tag :modal, true %>
             <%= hidden_field_tag :new_identifier, @group_identifier %>

--- a/app/views/transfer_requests/_new_modal.html.erb
+++ b/app/views/transfer_requests/_new_modal.html.erb
@@ -50,7 +50,7 @@
     </div>
     <%= form_for_transfer_admin @admin_view, @transfer_request do |f| %>
       <div class="modal-body">
-        <div class="error-space"><%= @transfer_request.errors.full_messages.join('. ') %></div>
+        <div class="error-space" role="alert" aria-live="assertive" aria-atomic="true"><%= @transfer_request.errors.full_messages.join('. ') %></div>
 
         <h5><label for="people_search"> <%=t('views.transfer_requests.new.transferee_label')%> </label><span class="hidden glyphicon glyphicon-refresh glyphicon-refresh-animate" aria-hidden="true"></span></h5>
 

--- a/app/views/urls/_in_row_errors.html.erb
+++ b/app/views/urls/_in_row_errors.html.erb
@@ -1,3 +1,3 @@
-<div class="error-space <%= !url.errors.empty? && 'tw-p-4' %>">
+<div class="error-space <%= !url.errors.empty? && 'tw-p-4' %>" role="alert" aria-live="assertive" aria-atomic="true">
   <%= url.errors.full_messages.join('. ') %>
 </div>


### PR DESCRIPTION
- add `role="alert"` to tell screenreaders that this is an alert message.
- add `aria-live="assertive"`  so screenreaders interrupt to announce errors immediately
- add `aria-atomic="true"` to read entire error message, not just changes

Updated admin pages while we're at it too.

Fixes https://github.com/UMN-LATIS/z/issues/232