### PR TITLE
fix(a11y): make click stats data available to screenreaders

### DIFF
--- a/app/views/urls/show.html.erb
+++ b/app/views/urls/show.html.erb
@@ -68,21 +68,117 @@
               <li role="presentation"><a href="#chart-div-all" data-load='all' data-toggle='tab' role='tab'><%= t('views.urls.show.all_time')%></a></li>
             </ul>
             <div class="col-md-12 tab-content">
-              <div role="tabpanel" class='tab-pane fade in active' id="chart-div-hrs24" ></div>
-              <div role="tabpanel" class='tab-pane fade' id="chart-div-days7"></div>
-              <div role="tabpanel" class='tab-pane fade' id="chart-div-days30"></div>
-              <div role="tabpanel" class='tab-pane fade' id="chart-div-all"></div>
+              <div role="tabpanel" class='tab-pane fade in active' id="chart-div-hrs24" aria-hidden="true"></div>
+              <div role="tabpanel" class='tab-pane fade' id="chart-div-days7" aria-hidden="true"></div>
+              <div role="tabpanel" class='tab-pane fade' id="chart-div-days30" aria-hidden="true"></div>
+              <div role="tabpanel" class='tab-pane fade' id="chart-div-all" aria-hidden="true"></div>
+            </div>
+            <!-- Accessible data tables for screen readers -->
+            <div class="sr-only">
+              <h4>Traffic Statistics Data Tables</h4>
+
+              <h5>Last 24 Hours</h5>
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Time</th>
+                    <th scope="col">Clicks</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% @clicks[:hrs24].each do |time, count| %>
+                    <tr>
+                      <td><%= time %></td>
+                      <td><%= count %></td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+
+              <h5>Last 7 Days</h5>
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Date</th>
+                    <th scope="col">Clicks</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% @clicks[:days7].each do |date, count| %>
+                    <tr>
+                      <td><%= date %></td>
+                      <td><%= count %></td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+
+              <h5>Last 30 Days</h5>
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Date</th>
+                    <th scope="col">Clicks</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% @clicks[:days30].each do |date, count| %>
+                    <tr>
+                      <td><%= date %></td>
+                      <td><%= count %></td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+
+              <h5>All Time</h5>
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Date</th>
+                    <th scope="col">Clicks</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% @clicks[:alltime].each do |date, count| %>
+                    <tr>
+                      <td><%= date %></td>
+                      <td><%= count %></td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
             </div>
           </div>
         </div>
         <h3><%= t('views.urls.show.traffic_location')%></h3>
         <div class="row">
-          <div id="regions-div" class="col-md-12">
+          <div id="regions-div" class="col-md-12" aria-hidden="true">
           </div>
         </div>
         <div class="row">
-          <div id="regions-pie-div" class="col-md-12">
+          <div id="regions-pie-div" class="col-md-12" aria-hidden="true">
           </div>
+        </div>
+        <!-- Accessible location data table for screen readers -->
+        <div class="sr-only">
+          <h4>Traffic by Location</h4>
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Country</th>
+                <th scope="col">Clicks</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @clicks[:regions].each do |country_code, count| %>
+                <tr>
+                  <td><%= country_code.present? ? country_code : 'Unknown' %></td>
+                  <td><%= count %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
         </div>
       </div>
       <div class="col-md-5">


### PR DESCRIPTION
- adds screen reader-only data tables for traffic and location statistics.
- updates markup to ensure that non-accessible visual charts are hidden from screenreaders

resolves #236
resolves #237