### PR TITLE
Add quoted exact match search to datatables

### DIFF
--- a/app/datatables/admin_audit_datatable.rb
+++ b/app/datatables/admin_audit_datatable.rb
@@ -3,9 +3,9 @@ class AdminAuditDatatable < ApplicationDatatable
 
   def view_columns
     @view_columns ||= {
-      item_type: { source: 'Audit.item_type' },
-      event: { source: 'Audit.event' },
-      whodunnit: { source: 'Audit.whodunnit' },
+      item_type: { source: 'Audit.item_type', cond: quoted_or_substring_match },
+      event: { source: 'Audit.event', cond: quoted_or_substring_match },
+      whodunnit: { source: 'Audit.whodunnit', cond: quoted_or_substring_match },
       audit_history: { source: 'Audit.version_history' },
       created_at: { source: 'Audit.created_at' }
     }

--- a/app/datatables/admin_group_datatable.rb
+++ b/app/datatables/admin_group_datatable.rb
@@ -6,8 +6,8 @@ class AdminGroupDatatable < ApplicationDatatable
     # or in aliased_join_table.column_name format
     @view_columns ||= {
       id: {source: "Group.id", cond: :eq},
-      name: {source: "Group.name", cond: :like},
-      description: {source: "Group.description"},
+      name: {source: "Group.name", cond: quoted_or_substring_match},
+      description: {source: "Group.description", cond: quoted_or_substring_match},
       users: {source: "Group.users", searchable: false, orderable: false},
       urls: {source: "Group.urls", searchable: false, orderable: false},
       actions: {searchable: false, orderable: false}

--- a/app/datatables/admin_url_datatable.rb
+++ b/app/datatables/admin_url_datatable.rb
@@ -6,21 +6,10 @@ class AdminUrlDatatable < ApplicationDatatable
     @view_columns ||= {
       id: { source: 'Url.id' },
       group_id: { source: 'Url.group_id' },
-      group_name: { source: 'Group.name' },
+      group_name: { source: 'Group.name', cond: quoted_or_substring_match },
       is_default_group: { source: 'Group.default?' },
-      url: { source: 'Url.url' },
-      keyword: {
-        source: 'Url.keyword',
-        cond: ->(column, value) {
-          if value.match?(/\A"(.+)"\z/)
-            # Quoted search: exact match (LIKE without wildcards is case-insensitive in MySQL)
-            column.table[column.field].matches(value.delete_prefix('"').delete_suffix('"'))
-          else
-            # Unquoted search: default substring match
-            column.table[column.field].matches("%#{value}%")
-          end
-        }
-      },
+      url: { source: 'Url.url', cond: quoted_or_substring_match },
+      keyword: { source: 'Url.keyword', cond: quoted_or_substring_match },
       total_clicks: { source: 'Url.total_clicks' },
       created_at: { source: 'Url.created_at' }
     }

--- a/app/datatables/admin_url_datatable.rb
+++ b/app/datatables/admin_url_datatable.rb
@@ -9,7 +9,18 @@ class AdminUrlDatatable < ApplicationDatatable
       group_name: { source: 'Group.name' },
       is_default_group: { source: 'Group.default?' },
       url: { source: 'Url.url' },
-      keyword: { source: 'Url.keyword' },
+      keyword: {
+        source: 'Url.keyword',
+        cond: ->(column, value) {
+          if value.match?(/\A"(.+)"\z/)
+            # Quoted search: exact match (LIKE without wildcards is case-insensitive in MySQL)
+            column.table[column.field].matches(value.delete_prefix('"').delete_suffix('"'))
+          else
+            # Unquoted search: default substring match
+            column.table[column.field].matches("%#{value}%")
+          end
+        }
+      },
       total_clicks: { source: 'Url.total_clicks' },
       created_at: { source: 'Url.created_at' }
     }

--- a/app/datatables/application_datatable.rb
+++ b/app/datatables/application_datatable.rb
@@ -12,14 +12,16 @@ class ApplicationDatatable < AjaxDatatablesRails::ActiveRecord
   # Without quotes, the default substring (LIKE %term%) match is used.
   def quoted_or_substring_match
     ->(column, value) {
-      if value.match?(/\A"(.+)"\z/)
-        # Escape _ so it matches literally (not as a single-char wildcard).
-        # We keep % unescaped so power users can do e.g. "abc%xyz".
-        # This is why we use `matches` (LIKE) instead of `eq` (=).
-        pattern = value.delete_prefix('"').delete_suffix('"').gsub("_", "\\_")
-        column.table[column.field].matches(pattern)
+      # Escape _ so it matches literally (not as a single-char wildcard).
+      # We keep % unescaped so power users can do e.g. "abc%xyz".
+      # This is why we use `matches` (LIKE) instead of `eq` (=).
+      escaped = value.gsub("_", "\\_")
+
+      if escaped.match?(/\A"(.+)"\z/)
+        quoted = escaped.delete_prefix('"').delete_suffix('"')
+        column.table[column.field].matches(quoted)
       else
-        column.table[column.field].matches("%#{value}%")
+        column.table[column.field].matches("%#{escaped}%")
       end
     }
   end

--- a/app/datatables/application_datatable.rb
+++ b/app/datatables/application_datatable.rb
@@ -6,4 +6,17 @@ class ApplicationDatatable < AjaxDatatablesRails::ActiveRecord
     @view = opts[:view_context]
     super
   end
+
+  # Returns a lambda for use as a custom :cond in view_columns.
+  # Wrap a search term in double quotes for an exact match, e.g. "hello".
+  # Without quotes, the default substring (LIKE %term%) match is used.
+  def quoted_or_substring_match
+    ->(column, value) {
+      if value.match?(/\A"(.+)"\z/)
+        column.table[column.field].matches(value.delete_prefix('"').delete_suffix('"'))
+      else
+        column.table[column.field].matches("%#{value}%")
+      end
+    }
+  end
 end

--- a/app/datatables/application_datatable.rb
+++ b/app/datatables/application_datatable.rb
@@ -13,7 +13,11 @@ class ApplicationDatatable < AjaxDatatablesRails::ActiveRecord
   def quoted_or_substring_match
     ->(column, value) {
       if value.match?(/\A"(.+)"\z/)
-        column.table[column.field].matches(value.delete_prefix('"').delete_suffix('"'))
+        # Escape _ so it matches literally (not as a single-char wildcard).
+        # We keep % unescaped so power users can do e.g. "abc%xyz".
+        # This is why we use `matches` (LIKE) instead of `eq` (=).
+        pattern = value.delete_prefix('"').delete_suffix('"').gsub("_", "\\_")
+        column.table[column.field].matches(pattern)
       else
         column.table[column.field].matches("%#{value}%")
       end

--- a/app/datatables/url_datatable.rb
+++ b/app/datatables/url_datatable.rb
@@ -10,10 +10,10 @@ class UrlDatatable < ApplicationDatatable
       # see: js method `initializeUrlDataTable()`
       '0': { searchable: false, orderable: false },
       group_id: { source: 'Url.group_id' },
-      group_name: { source: 'Group.name' },
-      url: { source: 'Url.url' },
-      keyword: { source: 'Url.keyword' },
-      note: { source: 'Url.note' },
+      group_name: { source: 'Group.name', cond: quoted_or_substring_match },
+      url: { source: 'Url.url', cond: quoted_or_substring_match },
+      keyword: { source: 'Url.keyword', cond: quoted_or_substring_match },
+      note: { source: 'Url.note', cond: quoted_or_substring_match },
       total_clicks: { source: 'Url.total_clicks', searchable: false },
       created_at: { source: 'Url.created_at' },
       # needed for actions like edit, delete, etc.

--- a/cypress/e2e/adminUrlExactSearch.cy.ts
+++ b/cypress/e2e/adminUrlExactSearch.cy.ts
@@ -1,0 +1,78 @@
+import admin from "../fixtures/users/admin.json";
+import user1 from "../fixtures/users/user1.json";
+
+describe("admin urls exact search", () => {
+  beforeEach(() => {
+    cy.app("clean");
+    cy.createAndLoginUser(admin.umndid, { admin: true });
+    cy.createUser(user1.umndid, {
+      internet_id_loaded: user1.internet_id,
+    }).then((user) => {
+      // Create URLs where short keyword is a substring of longer ones
+      cy.createUrl({
+        keyword: "go",
+        url: "https://go.umn.edu",
+        group_id: user.context_group_id,
+      });
+      cy.createUrl({
+        keyword: "google",
+        url: "https://google.com",
+        group_id: user.context_group_id,
+      });
+      cy.createUrl({
+        keyword: "gopher",
+        url: "https://gopher.umn.edu",
+        group_id: user.context_group_id,
+      });
+      cy.createUrl({
+        keyword: "golang",
+        url: "https://golang.org",
+        group_id: user.context_group_id,
+      });
+    });
+    cy.visit("/shortener/admin/urls");
+  });
+
+  it("returns only the exact match when keyword is quoted", () => {
+    // Type a quoted search term into the Z-link (keyword) column filter
+    // The keyword column filter is the first filter input
+    cy.get('[data-cy="admin-urls-table"] thead input[type="text"]')
+      .first()
+      .type('"go"');
+
+    // Wait for the server-side search to complete
+    cy.get('[data-cy="admin-urls-table"] tbody').should("not.contain", "Loading");
+
+    // Should show only the exact match "go", not "google", "gopher", "golang"
+    cy.get("[data-cy='admin-urls-table'] tbody > tr").should("have.length", 1);
+    cy.get("[data-cy='admin-urls-table'] tbody").should("contain", "go");
+    cy.get("[data-cy='admin-urls-table'] tbody").should("not.contain", "google");
+    cy.get("[data-cy='admin-urls-table'] tbody").should(
+      "not.contain",
+      "gopher"
+    );
+    cy.get("[data-cy='admin-urls-table'] tbody").should(
+      "not.contain",
+      "golang"
+    );
+  });
+
+  it("still returns substring matches when keyword is not quoted", () => {
+    // Type an unquoted search term — should behave as before (LIKE %go%)
+    cy.get('[data-cy="admin-urls-table"] thead input[type="text"]')
+      .first()
+      .type("go");
+
+    cy.get('[data-cy="admin-urls-table"] tbody').should("not.contain", "Loading");
+
+    // Should show all URLs containing "go"
+    cy.get("[data-cy='admin-urls-table'] tbody > tr").should(
+      "have.length.at.least",
+      4
+    );
+    cy.get("[data-cy='admin-urls-table'] tbody").should("contain", "go");
+    cy.get("[data-cy='admin-urls-table'] tbody").should("contain", "google");
+    cy.get("[data-cy='admin-urls-table'] tbody").should("contain", "gopher");
+    cy.get("[data-cy='admin-urls-table'] tbody").should("contain", "golang");
+  });
+});


### PR DESCRIPTION
- Fixes #271

Wrapping a search term in double quotes (e.g., `"cla"`) now performs an exact match instead of a substring match

https://github.com/user-attachments/assets/6f77bdf9-3524-4f58-93c1-27a938801b66
